### PR TITLE
Simplify goal modal with expandable notes & milestones

### DIFF
--- a/tests/anonymous-auth.spec.ts
+++ b/tests/anonymous-auth.spec.ts
@@ -37,10 +37,16 @@ test('anonymous user sees sign-in prompt instead of notes/milestones in goal mod
 	await page.getByTestId('goal-square').first().click();
 	await expect(page.getByTestId('goal-modal')).toBeVisible();
 
-	// Notes editor and milestones should be hidden for anonymous users
+	// Modal is collapsed by default — sign-in prompt not yet visible
+	await expect(page.getByTestId('sign-in-for-details')).not.toBeVisible();
+
+	// Expand the modal
+	await page.getByTestId('expand-modal-button').click();
+
+	// Notes editor and milestones should still be hidden for anonymous users
 	await expect(page.getByTestId('goal-notes-section')).not.toBeVisible();
 	await expect(page.getByTestId('goal-milestones-section')).not.toBeVisible();
 
-	// Sign-in prompt should be visible instead
+	// Sign-in prompt should be visible in the expanded area
 	await expect(page.getByTestId('sign-in-for-details')).toBeVisible();
 });

--- a/tests/date-metadata.spec.ts
+++ b/tests/date-metadata.spec.ts
@@ -52,9 +52,10 @@ test.describe('DateMetadata Component', () => {
 	});
 
 	test('shows lastUpdatedAt for new goals', async ({ page }) => {
-		// Open goal modal
+		// Open and expand goal modal
 		await page.getByTestId('goal-square').first().click();
 		await page.waitForSelector('[data-testid="goal-modal"]');
+		await page.getByTestId('expand-modal-button').click();
 
 		// Check that last updated is visible
 		const lastUpdatedText = await page.locator('text=Last updated:').textContent();
@@ -62,9 +63,10 @@ test.describe('DateMetadata Component', () => {
 	});
 
 	test('shows startedAt after first edit', async ({ page }) => {
-		// Open goal modal
+		// Open and expand goal modal
 		await page.getByTestId('goal-square').first().click();
 		await page.waitForSelector('[data-testid="goal-modal"]');
+		await page.getByTestId('expand-modal-button').click();
 
 		// Initially, startedAt should not be visible
 		const startedBefore = await page.locator('text=Started:').count();
@@ -79,9 +81,10 @@ test.describe('DateMetadata Component', () => {
 		await page.locator('[data-testid="close-modal-button"]').click();
 		await page.waitForTimeout(200);
 
-		// Reopen modal to see updated data
+		// Reopen and expand modal to see updated data
 		await page.getByTestId('goal-square').first().click();
 		await page.waitForSelector('[data-testid="goal-modal"]');
+		await page.getByTestId('expand-modal-button').click();
 
 		// Now startedAt should be visible
 		const startedAfter = await page.locator('text=Started:').count();
@@ -101,9 +104,10 @@ test.describe('DateMetadata Component', () => {
 		await page.getByTestId('goal-square').first().getByTestId('goal-checkbox').click();
 		await page.waitForTimeout(300);
 
-		// Open goal modal
+		// Open and expand goal modal
 		await page.getByTestId('goal-square').first().click();
 		await page.waitForSelector('[data-testid="goal-modal"]');
+		await page.getByTestId('expand-modal-button').click();
 
 		// CompletedAt should be visible
 		const completedCount = await page.locator('text=Completed:').count();
@@ -131,9 +135,10 @@ test.describe('DateMetadata Component', () => {
 		await page.getByTestId('goal-square').first().getByTestId('goal-checkbox').click();
 		await page.waitForTimeout(300);
 
-		// Open goal modal
+		// Open and expand goal modal
 		await page.getByTestId('goal-square').first().click();
 		await page.waitForSelector('[data-testid="goal-modal"]');
+		await page.getByTestId('expand-modal-button').click();
 
 		// CompletedAt should be visible
 		let completedCount = await page.locator('text=Completed:').count();
@@ -148,9 +153,10 @@ test.describe('DateMetadata Component', () => {
 		await page.locator('[data-testid="close-modal-button"]').click();
 		await page.waitForTimeout(200);
 
-		// Reopen modal
+		// Reopen and expand modal
 		await page.getByTestId('goal-square').first().click();
 		await page.waitForSelector('[data-testid="goal-modal"]');
+		await page.getByTestId('expand-modal-button').click();
 
 		// CompletedAt should not be visible
 		completedCount = await page.locator('text=Completed:').count();
@@ -158,9 +164,10 @@ test.describe('DateMetadata Component', () => {
 	});
 
 	test('formats lastUpdatedAt as relative time', async ({ page }) => {
-		// Open goal modal
+		// Open and expand goal modal
 		await page.getByTestId('goal-square').first().click();
 		await page.waitForSelector('[data-testid="goal-modal"]');
+		await page.getByTestId('expand-modal-button').click();
 
 		// Get the last updated text
 		const lastUpdatedText = await page

--- a/tests/milestone-crud.spec.ts
+++ b/tests/milestone-crud.spec.ts
@@ -69,9 +69,10 @@ test.describe('Milestone CRUD Operations', () => {
 
 	test.describe('addMilestone', () => {
 		test('should add a new milestone to a goal', async ({ page }) => {
-			// Open goal modal
+			// Open and expand goal modal
 			await page.getByTestId('goal-square').first().click();
 			await page.waitForSelector('[data-testid="goal-modal"]');
+			await page.getByTestId('expand-modal-button').click();
 
 			// Click Add milestone button
 			await page.click('text=+ Add');
@@ -108,9 +109,10 @@ test.describe('Milestone CRUD Operations', () => {
 		});
 
 		test('should increment position for each new milestone', async ({ page }) => {
-			// Open goal modal
+			// Open and expand goal modal
 			await page.getByTestId('goal-square').first().click();
 			await page.waitForSelector('[data-testid="goal-modal"]');
+			await page.getByTestId('expand-modal-button').click();
 
 			// Add first milestone
 			await page.click('text=+ Add');
@@ -163,9 +165,10 @@ test.describe('Milestone CRUD Operations', () => {
 			// Wait a bit to ensure timestamp will be different
 			await page.waitForTimeout(100);
 
-			// Open goal modal and add milestone
+			// Open and expand goal modal, then add milestone
 			await page.getByTestId('goal-square').first().click();
 			await page.waitForSelector('[data-testid="goal-modal"]');
+			await page.getByTestId('expand-modal-button').click();
 			await page.click('text=+ Add');
 			await page.fill('input[placeholder="New milestone..."]', 'Test Milestone');
 			await page.click('button.bg-blue-500:has-text("Add")');
@@ -193,9 +196,10 @@ test.describe('Milestone CRUD Operations', () => {
 
 	test.describe('updateMilestone', () => {
 		test('should update milestone title', async ({ page }) => {
-			// Open goal modal and add milestone
+			// Open and expand goal modal, then add milestone
 			await page.getByTestId('goal-square').first().click();
 			await page.waitForSelector('[data-testid="goal-modal"]');
+			await page.getByTestId('expand-modal-button').click();
 			await page.click('text=+ Add');
 			await page.fill('input[placeholder="New milestone..."]', 'Original Title');
 			await page.click('button.bg-blue-500:has-text("Add")');
@@ -232,9 +236,10 @@ test.describe('Milestone CRUD Operations', () => {
 
 	test.describe('toggleMilestoneComplete', () => {
 		test('should mark milestone as complete and set completedAt', async ({ page }) => {
-			// Open goal modal and add milestone
+			// Open and expand goal modal, then add milestone
 			await page.getByTestId('goal-square').first().click();
 			await page.waitForSelector('[data-testid="goal-modal"]');
+			await page.getByTestId('expand-modal-button').click();
 			await page.click('text=+ Add');
 			await page.fill('input[placeholder="New milestone..."]', 'Test Milestone');
 			await page.click('button.bg-blue-500:has-text("Add")');
@@ -265,9 +270,10 @@ test.describe('Milestone CRUD Operations', () => {
 		});
 
 		test('should clear completedAt when unchecked', async ({ page }) => {
-			// Open goal modal and add milestone
+			// Open and expand goal modal, then add milestone
 			await page.getByTestId('goal-square').first().click();
 			await page.waitForSelector('[data-testid="goal-modal"]');
+			await page.getByTestId('expand-modal-button').click();
 			await page.click('text=+ Add');
 			await page.fill('input[placeholder="New milestone..."]', 'Test Milestone');
 			await page.click('button.bg-blue-500:has-text("Add")');
@@ -304,9 +310,10 @@ test.describe('Milestone CRUD Operations', () => {
 
 	test.describe('deleteMilestone', () => {
 		test('should delete a milestone', async ({ page }) => {
-			// Open goal modal and add milestone
+			// Open and expand goal modal, then add milestone
 			await page.getByTestId('goal-square').first().click();
 			await page.waitForSelector('[data-testid="goal-modal"]');
+			await page.getByTestId('expand-modal-button').click();
 			await page.click('text=+ Add');
 			await page.fill('input[placeholder="New milestone..."]', 'Test Milestone');
 			await page.click('button.bg-blue-500:has-text("Add")');

--- a/tests/milestone-drag-drop.spec.ts
+++ b/tests/milestone-drag-drop.spec.ts
@@ -72,9 +72,10 @@ test.describe('Milestone Drag and Drop', () => {
 	});
 
 	test('renders milestones in position order', async ({ page }) => {
-		// Open goal modal
+		// Open and expand goal modal
 		await page.getByTestId('goal-square').first().click();
 		await page.waitForSelector('[data-testid="goal-modal"]');
+		await page.getByTestId('expand-modal-button').click();
 
 		// Add three milestones
 		const titles = ['First Milestone', 'Second Milestone', 'Third Milestone'];

--- a/tests/phase3-date-auto-population.spec.ts
+++ b/tests/phase3-date-auto-population.spec.ts
@@ -125,9 +125,10 @@ test.describe('Phase 3: Date Auto-Population Logic', () => {
 		});
 
 		test('should set on first notes edit', async ({ page }) => {
-			// Open sidebar for first goal
+			// Open and expand modal for first goal
 			await page.getByTestId('goal-square').first().click();
 			await page.waitForSelector('[data-testid="goal-modal"]');
+			await page.getByTestId('expand-modal-button').click();
 
 			// Edit notes (skip title)
 			const richTextEditor = page.getByTestId('rich-text-editor');
@@ -409,9 +410,10 @@ test.describe('Phase 3: Date Auto-Population Logic', () => {
 			// Wait to ensure time difference
 			await page.waitForTimeout(100);
 
-			// Edit notes
+			// Open and expand modal, then edit notes
 			await page.getByTestId('goal-square').first().click();
 			await page.waitForSelector('[data-testid="goal-modal"]');
+			await page.getByTestId('expand-modal-button').click();
 
 			const richTextEditor = page.getByTestId('rich-text-editor');
 			await richTextEditor.click();

--- a/tests/rich-text-editor.spec.ts
+++ b/tests/rich-text-editor.spec.ts
@@ -7,6 +7,7 @@ import {
 	deleteTestBoard,
 	getFirstGoalId,
 	openFirstGoalModal,
+	expandGoalModal,
 	closeModal,
 	waitForAutoSave,
 	getGoalData
@@ -29,6 +30,7 @@ test.describe('RichTextEditor Component', () => {
 
 	test('should render editor with toolbar buttons', async ({ page }) => {
 		await openFirstGoalModal(page);
+		await expandGoalModal(page);
 
 		// Verify all toolbar buttons are present
 		const toolbarButtons = [
@@ -55,6 +57,7 @@ test.describe('RichTextEditor Component', () => {
 		for (const { name, button, tag, text } of formattingTests) {
 			test(`should apply ${name} formatting`, async ({ page }) => {
 				await openFirstGoalModal(page);
+		await expandGoalModal(page);
 
 				const editor = page.getByTestId('rich-text-editor');
 				await editor.click();
@@ -83,6 +86,7 @@ test.describe('RichTextEditor Component', () => {
 		for (const { name, button, tag } of listTests) {
 			test(`should create ${name}`, async ({ page }) => {
 				await openFirstGoalModal(page);
+		await expandGoalModal(page);
 
 				const editor = page.getByTestId('rich-text-editor');
 				await editor.click();
@@ -100,6 +104,7 @@ test.describe('RichTextEditor Component', () => {
 
 	test('should persist rich text formatting after close and reopen', async ({ page }) => {
 		await openFirstGoalModal(page);
+		await expandGoalModal(page);
 
 		// Add formatted text
 		const editor = page.getByTestId('rich-text-editor');
@@ -114,6 +119,7 @@ test.describe('RichTextEditor Component', () => {
 
 		// Reopen modal
 		await openFirstGoalModal(page);
+		await expandGoalModal(page);
 
 		// Verify formatting persists
 		const boldElement = page.getByTestId('rich-text-editor').locator('strong, b');
@@ -123,6 +129,7 @@ test.describe('RichTextEditor Component', () => {
 
 	test('should persist rich text HTML to database', async ({ page }) => {
 		await openFirstGoalModal(page);
+		await expandGoalModal(page);
 
 		// Add formatted text
 		const editor = page.getByTestId('rich-text-editor');
@@ -142,6 +149,7 @@ test.describe('RichTextEditor Component', () => {
 
 	test('should handle keyboard shortcuts for formatting', async ({ page }) => {
 		await openFirstGoalModal(page);
+		await expandGoalModal(page);
 
 		const editor = page.getByTestId('rich-text-editor');
 		await editor.click();
@@ -157,6 +165,7 @@ test.describe('RichTextEditor Component', () => {
 
 	test('should show active state for formatting buttons', async ({ page }) => {
 		await openFirstGoalModal(page);
+		await expandGoalModal(page);
 
 		const editor = page.getByTestId('rich-text-editor');
 		await editor.click();

--- a/tests/test-helpers.ts
+++ b/tests/test-helpers.ts
@@ -112,6 +112,13 @@ export async function openFirstGoalModal(page: Page): Promise<void> {
 }
 
 /**
+ * Expands the goal modal to show notes, milestones, and date metadata
+ */
+export async function expandGoalModal(page: Page): Promise<void> {
+	await page.getByTestId('expand-modal-button').click();
+}
+
+/**
  * Closes the modal using Escape key
  */
 export async function closeModal(page: Page): Promise<void> {


### PR DESCRIPTION
Default view shows only title and completion toggle — lean for the TikTok-first audience. A labeled "Notes & milestones ↓" button at the bottom of the modal expands to reveal notes (rich text), milestones, and date metadata for signed-in users. Anonymous users see a sign-in prompt when they expand.

Removes ConversionPrompt from GoalModal; the expand flow handles that pattern more cleanly.