### PR TITLE
Replace bingo banner with confetti animation and cell pulse

### DIFF
--- a/src/lib/components/BingoBoard.svelte
+++ b/src/lib/components/BingoBoard.svelte
@@ -4,26 +4,19 @@
 	import { detectBingo, type BingoLine } from '$lib/utils/bingo';
 	import GoalSquare from './GoalSquare.svelte';
 	import GoalModal from './GoalModal.svelte';
+	import Confetti from './Confetti.svelte';
 
 	let bingoLines = $derived<BingoLine[]>($currentBoard ? detectBingo($currentBoard) : []);
 	let hasBingo = $derived(bingoLines.length > 0);
 	let bingoIndices = $derived(new Set(bingoLines.flatMap((line) => line.indices)));
 </script>
 
+{#if hasBingo}
+	<Confetti />
+{/if}
+
 {#if $currentBoard}
 	<div class="bg-white rounded-lg shadow-lg p-2 sm:p-3 md:p-4 relative">
-		{#if hasBingo}
-			<div
-				class="celebrate mb-3 sm:mb-4 p-3 sm:p-4 bg-gradient-to-r from-yellow-100 to-green-100 border-2 border-yellow-500 rounded-lg text-center shadow-md"
-			>
-				<p class="text-xl sm:text-2xl font-bold text-yellow-800">🎉 BINGO! 🎉</p>
-				<p class="text-xs sm:text-sm text-yellow-700 mt-1">
-					You completed {bingoLines.length}
-					{bingoLines.length === 1 ? 'line' : 'lines'}!
-				</p>
-			</div>
-		{/if}
-
 		<div
 			class="grid gap-2 sm:gap-3"
 			style="grid-template-columns: repeat({$currentBoard.size}, minmax(0, 1fr));"
@@ -48,20 +41,3 @@
 	/>
 {/if}
 
-<style>
-	@keyframes pulse-celebration {
-		0%,
-		100% {
-			transform: scale(1);
-			opacity: 1;
-		}
-		50% {
-			transform: scale(1.02);
-			opacity: 0.95;
-		}
-	}
-
-	.celebrate {
-		animation: pulse-celebration 2s ease-in-out infinite;
-	}
-</style>

--- a/src/lib/components/Confetti.svelte
+++ b/src/lib/components/Confetti.svelte
@@ -1,0 +1,85 @@
+<!-- ABOUTME: Full-page confetti animation overlay for bingo celebrations -->
+<!-- ABOUTME: Renders randomized particles that fall from top to bottom of the viewport -->
+
+<script lang="ts">
+	const PARTICLE_COUNT = 80;
+	const COLORS = ['#f43f5e', '#f97316', '#eab308', '#22c55e', '#3b82f6', '#a855f7', '#ec4899'];
+
+	interface Particle {
+		id: number;
+		color: string;
+		left: number;
+		delay: number;
+		duration: number;
+		width: number;
+		height: number;
+		startRotation: number;
+	}
+
+	function randomBetween(min: number, max: number): number {
+		return Math.random() * (max - min) + min;
+	}
+
+	const particles: Particle[] = Array.from({ length: PARTICLE_COUNT }, (_, i) => ({
+		id: i,
+		color: COLORS[Math.floor(Math.random() * COLORS.length)],
+		left: randomBetween(0, 100),
+		delay: randomBetween(0, 3),
+		duration: randomBetween(2.5, 4.5),
+		width: randomBetween(6, 12),
+		height: randomBetween(8, 16),
+		startRotation: randomBetween(0, 360)
+	}));
+</script>
+
+<div class="confetti-container" aria-hidden="true">
+	{#each particles as p (p.id)}
+		<div
+			class="confetti-piece"
+			style="
+				left: {p.left}vw;
+				background-color: {p.color};
+				width: {p.width}px;
+				height: {p.height}px;
+				animation-delay: {p.delay}s;
+				animation-duration: {p.duration}s;
+				--start-rotation: {p.startRotation}deg;
+			"
+		></div>
+	{/each}
+</div>
+
+<style>
+	.confetti-container {
+		position: fixed;
+		top: 0;
+		left: 0;
+		width: 100%;
+		height: 100%;
+		pointer-events: none;
+		z-index: 1000;
+		overflow: hidden;
+	}
+
+	.confetti-piece {
+		position: absolute;
+		top: -20px;
+		border-radius: 2px;
+		opacity: 0;
+		animation: confetti-fall linear forwards;
+	}
+
+	@keyframes confetti-fall {
+		0% {
+			transform: translateY(0) rotate(var(--start-rotation));
+			opacity: 1;
+		}
+		80% {
+			opacity: 1;
+		}
+		100% {
+			transform: translateY(105vh) rotate(calc(var(--start-rotation) + 720deg));
+			opacity: 0;
+		}
+	}
+</style>

--- a/src/lib/components/GoalSquare.svelte
+++ b/src/lib/components/GoalSquare.svelte
@@ -76,6 +76,28 @@
 	}
 </script>
 
+<style>
+	@keyframes bingo-pulse {
+		0%,
+		100% {
+			transform: scale(1);
+			box-shadow:
+				0 0 0 0 rgba(234, 179, 8, 0.4),
+				0 4px 6px -1px rgba(0, 0, 0, 0.1);
+		}
+		50% {
+			transform: scale(1.04);
+			box-shadow:
+				0 0 0 6px rgba(234, 179, 8, 0.2),
+				0 10px 15px -3px rgba(0, 0, 0, 0.1);
+		}
+	}
+
+	:global(.bingo-winner) {
+		animation: bingo-pulse 1.5s ease-in-out infinite;
+	}
+</style>
+
 <div
 	data-testid="goal-square"
 	role="button"
@@ -84,7 +106,7 @@
 	onkeydown={(e) => e.key === 'Enter' && selectGoal()}
 	class="aspect-square border-2 rounded-lg p-1 sm:p-2 md:p-3 lg:p-4 cursor-pointer transition-all duration-200 hover:shadow-md active:scale-95 overflow-hidden {isInBingo &&
 	goal.completed
-		? 'bg-yellow-50 border-yellow-500 shadow-lg ring-2 ring-yellow-400 ring-offset-2'
+		? 'bingo-winner bg-yellow-50 border-yellow-500 shadow-lg ring-2 ring-yellow-400 ring-offset-2'
 		: goal.completed
 			? 'bg-green-50 border-green-500'
 			: 'bg-white border-gray-300 hover:border-blue-400'}"


### PR DESCRIPTION
- Remove the static header/banner shown on bingo
- Add Confetti.svelte: 80 randomized particles rain across the full viewport (fixed overlay, pointer-events none, z-index 1000)
- Winning cells now pulse with a scale+glow animation via bingo-pulse keyframes, on top of the existing yellow highlight