### PR TITLE
Redesign dashboard UI: cleaner header, simplified board cards and modals

### DIFF
--- a/src/lib/components/BoardCard.svelte
+++ b/src/lib/components/BoardCard.svelte
@@ -55,10 +55,7 @@
 				>
 					{board.name}
 				</h3>
-				<p class="text-sm text-gray-500 mt-1">
-					{board.size}×{board.size} grid • {totalGoals} goals
-				</p>
-			</div>
+				</div>
 
 			<!-- Delete Button -->
 			{#if onDelete}
@@ -161,22 +158,7 @@
 				{/if}
 			</div>
 
-			<span class="text-xs text-gray-400">{formatDate(board.createdAt)}</span>
-		</div>
-	</div>
-
-	<!-- Footer - View Board -->
-	<div class="px-4 py-3 bg-gray-50 border-t border-gray-100">
-		<div class="flex items-center justify-between text-sm">
-			<span class="text-blue-600 font-medium group-hover:text-blue-700">View board</span>
-			<svg
-				class="w-5 h-5 text-blue-600 group-hover:translate-x-1 transition-transform"
-				fill="none"
-				stroke="currentColor"
-				viewBox="0 0 24 24"
-			>
-				<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" />
-			</svg>
+			<span class="text-xs text-gray-400">Created {formatDate(board.createdAt)}</span>
 		</div>
 	</div>
 </a>

--- a/src/lib/components/CreateBoardModal.svelte
+++ b/src/lib/components/CreateBoardModal.svelte
@@ -9,7 +9,6 @@
 	let { isOpen, onClose }: Props = $props();
 
 	let name = $state('');
-	let size = $state(3);
 	let loading = $state(false);
 	let error = $state('');
 	let nameInput = $state<HTMLInputElement | undefined>(undefined);
@@ -18,7 +17,6 @@
 	$effect(() => {
 		if (isOpen) {
 			name = '';
-			size = 3;
 			error = '';
 			// Focus the name input after a brief delay to ensure modal is rendered
 			setTimeout(() => nameInput?.focus(), 100);
@@ -42,7 +40,7 @@
 		loading = true;
 		error = '';
 
-		const result = await boardsStore.createBoard(name.trim(), size);
+		const result = await boardsStore.createBoard(name.trim(), 5);
 
 		loading = false;
 
@@ -68,7 +66,7 @@
 
 {#if isOpen}
 	<div
-		class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black bg-opacity-50 backdrop-blur-sm"
+		class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/20"
 		onclick={handleBackdropClick}
 		onkeydown={handleKeydown}
 		role="dialog"
@@ -96,8 +94,7 @@
 						</svg>
 					</button>
 				</div>
-				<p class="text-blue-100 text-sm mt-1">Set up your bingo board</p>
-			</div>
+				</div>
 
 			<!-- Form -->
 			<form onsubmit={handleSubmit} class="p-6 space-y-5">
@@ -118,57 +115,6 @@
 						class="w-full px-4 py-3 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500 outline-none disabled:bg-gray-100 disabled:cursor-not-allowed transition-colors"
 					/>
 					<p class="text-xs text-gray-500 mt-1">Give your board a memorable name</p>
-				</div>
-
-				<!-- Board Size -->
-				<div>
-					<div class="block text-sm font-medium text-gray-700 mb-3">
-						Board Size <span class="text-red-500">*</span>
-					</div>
-					<div class="grid grid-cols-3 gap-3">
-						{#each [3, 4, 5] as sizeOption}
-							<button
-								type="button"
-								onclick={() => (size = sizeOption)}
-								disabled={loading}
-								class="relative p-4 border-2 rounded-lg transition-all disabled:cursor-not-allowed {size ===
-								sizeOption
-									? 'border-blue-600 bg-blue-50'
-									: 'border-gray-200 hover:border-blue-300 bg-white'}"
-							>
-								{#if size === sizeOption}
-									<div class="absolute top-2 right-2">
-										<svg
-											class="w-5 h-5 text-blue-600"
-											fill="none"
-											stroke="currentColor"
-											viewBox="0 0 24 24"
-										>
-											<path
-												stroke-linecap="round"
-												stroke-linejoin="round"
-												stroke-width="2"
-												d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-											/>
-										</svg>
-									</div>
-								{/if}
-								<div class="text-center">
-									<div
-										class="text-2xl font-bold {size === sizeOption
-											? 'text-blue-600'
-											: 'text-gray-700'}"
-									>
-										{sizeOption}×{sizeOption}
-									</div>
-									<div class="text-xs text-gray-500 mt-1">
-										{sizeOption * sizeOption} goals
-									</div>
-								</div>
-							</button>
-						{/each}
-					</div>
-					<p class="text-xs text-gray-500 mt-2">Choose how many goals you want on your board</p>
 				</div>
 
 				<!-- Error Message -->
@@ -197,7 +143,7 @@
 				{/if}
 
 				<!-- Actions -->
-				<div class="flex items-center justify-end space-x-3 pt-4 border-t">
+				<div class="flex items-center justify-end space-x-3">
 					<button
 						type="button"
 						onclick={onClose}

--- a/src/lib/components/DeleteBoardModal.svelte
+++ b/src/lib/components/DeleteBoardModal.svelte
@@ -6,9 +6,10 @@
 		isOpen: boolean;
 		board: Board | null;
 		onClose: () => void;
+		onDeleted?: (boardName: string) => void;
 	}
 
-	let { isOpen, board, onClose }: Props = $props();
+	let { isOpen, board, onClose, onDeleted }: Props = $props();
 
 	let loading = $state(false);
 	let error = $state('');
@@ -31,7 +32,9 @@
 		loading = false;
 
 		if (result.success) {
+			const name = board.name;
 			onClose();
+			onDeleted?.(name);
 		} else {
 			error = result.error || 'Failed to delete board';
 		}
@@ -52,7 +55,7 @@
 
 {#if isOpen && board}
 	<div
-		class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black bg-opacity-50 backdrop-blur-sm"
+		class="fixed inset-0 z-50 flex items-center justify-center p-4 bg-black/20"
 		onclick={handleBackdropClick}
 		onkeydown={handleKeydown}
 		role="dialog"
@@ -110,9 +113,6 @@
 				<div class="bg-gray-50 rounded-lg p-4 border border-gray-200">
 					<p class="text-sm text-gray-600 mb-1">Board to delete:</p>
 					<p class="font-semibold text-gray-900 text-lg">{board.name}</p>
-					<p class="text-sm text-gray-500 mt-1">
-						{board.size}×{board.size} grid • {board.goals.length} goals
-					</p>
 				</div>
 
 				<!-- Warning Message -->

--- a/src/lib/components/UserMenu.svelte
+++ b/src/lib/components/UserMenu.svelte
@@ -53,7 +53,7 @@
 		<!-- Login Button (unauthenticated / anonymous) -->
 		<a
 			href="/auth/login"
-			class="px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors"
+			class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors"
 		>
 			Login
 		</a>

--- a/src/routes/boards/[id]/+page.svelte
+++ b/src/routes/boards/[id]/+page.svelte
@@ -38,7 +38,7 @@
 		<!-- Header -->
 		<header class="bg-grey/50">
 			<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-				<div class="relative flex items-center justify-between">
+				<div class="relative flex items-center justify-between h-10">
 					<!-- Board Title (absolutely centered) -->
 					<div class="absolute inset-0 flex items-center justify-center pointer-events-none">
 						{#if $currentBoard}
@@ -54,7 +54,7 @@
 					<div></div>
 
 					<!-- Right side: Dashboard button + User Menu -->
-					<div class="flex items-center space-x-2">
+					<div class="flex items-center gap-3">
 						<a
 							href="/dashboard"
 							class="px-4 py-2 text-sm font-medium text-gray-700 hover:text-gray-900 hover:bg-gray-100 rounded-lg transition-colors"

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -12,6 +12,7 @@
 	let showCreateModal = $state(false);
 	let showDeleteModal = $state(false);
 	let boardToDelete: Board | null = $state(null);
+	let deletedBoardName = $state<string | null>(null);
 
 	// Fetch boards when component mounts
 	onMount(() => {
@@ -39,6 +40,11 @@
 		boardToDelete = null;
 	}
 
+	function handleBoardDeleted(boardName: string) {
+		deletedBoardName = boardName;
+		setTimeout(() => (deletedBoardName = null), 3000);
+	}
+
 	async function handleRetryFetch() {
 		await boardsStore.fetchBoards();
 	}
@@ -51,7 +57,7 @@
 <AuthGuard>
 	<div class="min-h-screen">
 		<!-- Header -->
-		<header class="bg-white/50 border-b border-gray-200">
+		<header class="bg-transparent">
 			<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
 				<div class="flex items-center justify-between">
 					<div class="flex items-center space-x-3">
@@ -65,10 +71,26 @@
 								/>
 							</svg>
 						</div>
-						<h1 class="text-xl font-bold text-gray-900">Bingo Board</h1>
+						<h1 class="text-xl font-bold text-gray-900">BINGOAL</h1>
 					</div>
 
+					<div class="flex items-center gap-3">
+					<button
+						onclick={handleCreateBoard}
+						class="flex items-center px-4 py-2 text-sm bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors shadow-sm hover:shadow-md"
+					>
+						<svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+							<path
+								stroke-linecap="round"
+								stroke-linejoin="round"
+								stroke-width="2"
+								d="M12 6v6m0 0v6m0-6h6m-6 0H6"
+							/>
+						</svg>
+						New Board
+					</button>
 					<UserMenu />
+				</div>
 				</div>
 			</div>
 		</header>
@@ -76,25 +98,9 @@
 		<!-- Main Content -->
 		<main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
 			<!-- Page Header -->
-			<div class="flex items-center justify-between mb-8">
-				<div>
-					<h2 class="text-3xl font-bold text-gray-900">My Boards</h2>
-					<p class="text-gray-600 mt-1">Create and manage your bingo boards</p>
-				</div>
-				<button
-					onclick={handleCreateBoard}
-					class="flex items-center px-4 py-2.5 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors shadow-sm hover:shadow-md"
-				>
-					<svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-						<path
-							stroke-linecap="round"
-							stroke-linejoin="round"
-							stroke-width="2"
-							d="M12 6v6m0 0v6m0-6h6m-6 0H6"
-						/>
-					</svg>
-					New Board
-				</button>
+			<div class="mb-8">
+				<h2 class="text-3xl font-bold text-gray-900">My Boards</h2>
+				<p class="text-gray-600 mt-1">Create and manage your bingo boards</p>
 			</div>
 
 			<!-- Error State -->
@@ -180,5 +186,18 @@
 		isOpen={showDeleteModal}
 		board={boardToDelete}
 		onClose={handleCloseDeleteModal}
+		onDeleted={handleBoardDeleted}
 	/>
+
+	<!-- Delete success toast -->
+	{#if deletedBoardName}
+		<div class="fixed bottom-6 left-1/2 -translate-x-1/2 z-50">
+			<div class="flex items-center gap-3 bg-gray-900 text-white px-4 py-3 rounded-lg shadow-lg text-sm">
+				<svg class="w-4 h-4 text-green-400 flex-shrink-0" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 13l4 4L19 7" />
+				</svg>
+				<span>"{deletedBoardName}" was deleted</span>
+			</div>
+		</div>
+	{/if}
 </AuthGuard>


### PR DESCRIPTION
- Rename app title to BINGOAL, make header transparent, remove divider
- Move New Board button to header next to login; align button sizes
- Remove grid/goals metadata from board cards and delete modal
- Remove View Board footer from board cards
- Label creation date as "Created"
- Simplify create modal: fixed 5x5 size, lighter backdrop
- Lighter backdrop on delete modal
- Show success toast after board deletion
- Fix header height consistency between dashboard and board view