### PR TITLE
Redesign welcome page header and align UI across all pages

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,6 +2,7 @@
 	import { goto } from '$app/navigation';
 	import { authError, authStore, isAuthInitialized } from '$lib/stores/auth';
 	import { boardsStore } from '$lib/stores/boards';
+	import UserMenu from '$lib/components/UserMenu.svelte';
 
 	let boardName = $state('My 2026 Goals');
 	let creating = $state(false);
@@ -71,7 +72,36 @@
 	</div>
 {:else}
 	<!-- Landing page with inline board creation -->
-	<div class="min-h-screen flex items-center justify-center p-4">
+	<div class="min-h-screen flex flex-col">
+		<!-- Header -->
+		<header class="bg-transparent">
+			<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
+				<div class="flex items-center justify-between">
+					<a href="/" class="flex items-center space-x-3">
+						<div class="w-10 h-10 bg-blue-600 rounded-lg flex items-center justify-center">
+							<svg class="w-6 h-6" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+								<rect x="1" y="1" width="6" height="6" rx="1.5" fill="white"/>
+								<polygon points="4,1.8 4.529,3.272 6.092,3.320 4.856,4.278 5.293,5.780 4,4.9 2.707,5.780 3.144,4.278 1.908,3.320 3.471,3.272" fill="#2563eb"/>
+								<rect x="8" y="1" width="6" height="6" rx="1.5" stroke="white" stroke-width="1.5"/>
+								<rect x="15" y="1" width="6" height="6" rx="1.5" stroke="white" stroke-width="1.5"/>
+								<rect x="1" y="8" width="6" height="6" rx="1.5" stroke="white" stroke-width="1.5"/>
+								<rect x="8" y="8" width="6" height="6" rx="1.5" fill="white"/>
+								<polygon points="11,8.8 11.529,10.272 13.092,10.320 11.856,11.278 12.293,12.780 11,11.9 9.707,12.780 10.144,11.278 8.908,10.320 10.471,10.272" fill="#2563eb"/>
+								<rect x="15" y="8" width="6" height="6" rx="1.5" stroke="white" stroke-width="1.5"/>
+								<rect x="1" y="15" width="6" height="6" rx="1.5" stroke="white" stroke-width="1.5"/>
+								<rect x="8" y="15" width="6" height="6" rx="1.5" stroke="white" stroke-width="1.5"/>
+								<rect x="15" y="15" width="6" height="6" rx="1.5" fill="white"/>
+								<polygon points="18,15.8 18.529,17.272 20.092,17.320 18.856,18.278 19.293,19.780 18,18.9 16.707,19.780 17.144,18.278 15.908,17.320 17.471,17.272" fill="#2563eb"/>
+							</svg>
+						</div>
+						<h1 class="text-xl font-bold text-gray-900">BINGOAL</h1>
+					</a>
+					<UserMenu />
+				</div>
+			</div>
+		</header>
+
+		<div class="flex-1 flex items-center justify-center p-4">
 		<div class="max-w-2xl w-full">
 			<div class="text-center mb-8">
 				<h1 class="text-4xl sm:text-5xl font-bold text-gray-900 mb-4">
@@ -218,16 +248,15 @@
 				</div>
 			</div>
 
-			<!-- Footer -->
-			<div class="mt-8 text-center">
-				<p class="text-sm text-gray-600">
-					Already have an account?
-					<a href="/auth/login" class="text-blue-600 hover:text-blue-700 font-medium">
-						Sign in
-					</a>
-				</p>
 			</div>
 		</div>
+		<footer class="py-6 text-center text-sm text-gray-400">
+			<p>© {new Date().getFullYear()} Bingoal &middot;
+				<a href="/privacy" class="hover:text-gray-600 transition-colors">Privacy</a>
+				&middot;
+				<a href="/terms" class="hover:text-gray-600 transition-colors">Terms</a>
+			</p>
+		</footer>
 	</div>
 {/if}
 

--- a/src/routes/boards/[id]/+page.svelte
+++ b/src/routes/boards/[id]/+page.svelte
@@ -36,24 +36,29 @@
 <AuthGuard>
 	<div class="min-h-screen">
 		<!-- Header -->
-		<header class="bg-grey/50">
+		<header class="bg-transparent">
 			<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
-				<div class="relative flex items-center justify-between h-10">
-					<!-- Board Title (absolutely centered) -->
-					<div class="absolute inset-0 flex items-center justify-center pointer-events-none">
-						{#if $currentBoard}
-							<h1 class="text-3xl font-bold text-gray-900">
-								{$currentBoard.name}
-							</h1>
-						{:else}
-							<div class="h-8 w-48 bg-gray-200 rounded animate-pulse"></div>
-						{/if}
-					</div>
+				<div class="flex items-center justify-between">
+					<a href="/" class="flex items-center space-x-3">
+						<div class="w-10 h-10 bg-blue-600 rounded-lg flex items-center justify-center">
+							<svg class="w-6 h-6" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+								<rect x="1" y="1" width="6" height="6" rx="1.5" fill="white"/>
+								<polygon points="4,1.8 4.529,3.272 6.092,3.320 4.856,4.278 5.293,5.780 4,4.9 2.707,5.780 3.144,4.278 1.908,3.320 3.471,3.272" fill="#2563eb"/>
+								<rect x="8" y="1" width="6" height="6" rx="1.5" stroke="white" stroke-width="1.5"/>
+								<rect x="15" y="1" width="6" height="6" rx="1.5" stroke="white" stroke-width="1.5"/>
+								<rect x="1" y="8" width="6" height="6" rx="1.5" stroke="white" stroke-width="1.5"/>
+								<rect x="8" y="8" width="6" height="6" rx="1.5" fill="white"/>
+								<polygon points="11,8.8 11.529,10.272 13.092,10.320 11.856,11.278 12.293,12.780 11,11.9 9.707,12.780 10.144,11.278 8.908,10.320 10.471,10.272" fill="#2563eb"/>
+								<rect x="15" y="8" width="6" height="6" rx="1.5" stroke="white" stroke-width="1.5"/>
+								<rect x="1" y="15" width="6" height="6" rx="1.5" stroke="white" stroke-width="1.5"/>
+								<rect x="8" y="15" width="6" height="6" rx="1.5" stroke="white" stroke-width="1.5"/>
+								<rect x="15" y="15" width="6" height="6" rx="1.5" fill="white"/>
+								<polygon points="18,15.8 18.529,17.272 20.092,17.320 18.856,18.278 19.293,19.780 18,18.9 16.707,19.780 17.144,18.278 15.908,17.320 17.471,17.272" fill="#2563eb"/>
+							</svg>
+						</div>
+						<span class="text-xl font-bold text-gray-900">BINGOAL</span>
+					</a>
 
-					<!-- Left placeholder -->
-					<div></div>
-
-					<!-- Right side: Dashboard button + User Menu -->
 					<div class="flex items-center gap-3">
 						<a
 							href="/dashboard"
@@ -69,6 +74,14 @@
 
 		<!-- Main Content -->
 		<main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-3 sm:py-4">
+			<!-- Board Title -->
+			<div class="mb-4 text-center">
+				{#if $currentBoard}
+					<h1 class="text-3xl font-bold text-gray-900">{$currentBoard.name}</h1>
+				{:else if !$currentBoardError}
+					<div class="h-8 w-48 bg-gray-200 rounded animate-pulse mx-auto"></div>
+				{/if}
+			</div>
 			{#if $currentBoardLoading}
 				<!-- Loading State -->
 				<div

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -60,19 +60,25 @@
 		<header class="bg-transparent">
 			<div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
 				<div class="flex items-center justify-between">
-					<div class="flex items-center space-x-3">
+					<a href="/" class="flex items-center space-x-3">
 						<div class="w-10 h-10 bg-blue-600 rounded-lg flex items-center justify-center">
-							<svg class="w-6 h-6 text-white" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="2"
-									d="M9 5H7a2 2 0 00-2 2v12a2 2 0 002 2h10a2 2 0 002-2V7a2 2 0 00-2-2h-2M9 5a2 2 0 002 2h2a2 2 0 002-2M9 5a2 2 0 012-2h2a2 2 0 012 2m-6 9l2 2 4-4"
-								/>
+							<svg class="w-6 h-6" viewBox="0 0 22 22" fill="none" xmlns="http://www.w3.org/2000/svg">
+								<rect x="1" y="1" width="6" height="6" rx="1.5" fill="white"/>
+								<polygon points="4,1.8 4.529,3.272 6.092,3.320 4.856,4.278 5.293,5.780 4,4.9 2.707,5.780 3.144,4.278 1.908,3.320 3.471,3.272" fill="#2563eb"/>
+								<rect x="8" y="1" width="6" height="6" rx="1.5" stroke="white" stroke-width="1.5"/>
+								<rect x="15" y="1" width="6" height="6" rx="1.5" stroke="white" stroke-width="1.5"/>
+								<rect x="1" y="8" width="6" height="6" rx="1.5" stroke="white" stroke-width="1.5"/>
+								<rect x="8" y="8" width="6" height="6" rx="1.5" fill="white"/>
+								<polygon points="11,8.8 11.529,10.272 13.092,10.320 11.856,11.278 12.293,12.780 11,11.9 9.707,12.780 10.144,11.278 8.908,10.320 10.471,10.272" fill="#2563eb"/>
+								<rect x="15" y="8" width="6" height="6" rx="1.5" stroke="white" stroke-width="1.5"/>
+								<rect x="1" y="15" width="6" height="6" rx="1.5" stroke="white" stroke-width="1.5"/>
+								<rect x="8" y="15" width="6" height="6" rx="1.5" stroke="white" stroke-width="1.5"/>
+								<rect x="15" y="15" width="6" height="6" rx="1.5" fill="white"/>
+								<polygon points="18,15.8 18.529,17.272 20.092,17.320 18.856,18.278 19.293,19.780 18,18.9 16.707,19.780 17.144,18.278 15.908,17.320 17.471,17.272" fill="#2563eb"/>
 							</svg>
 						</div>
 						<h1 class="text-xl font-bold text-gray-900">BINGOAL</h1>
-					</div>
+					</a>
 
 					<div class="flex items-center gap-3">
 					<button


### PR DESCRIPTION
- Add BINGOAL header to welcome page (matching dashboard/board view)
- Add UserMenu to welcome page (login button for anon, avatar for authed users)
- Make BINGOAL logo a link to / on all three pages
- Move board title below header on board view, centered
- Replace clipboard icon with bingo grid icon (diagonal star pattern) on all pages
- Add copyright/Privacy/Terms footer to welcome page
- Remove redundant "Already have an account? Sign in" link