### PR TITLE
feat: implement get_goals agent primitive

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -743,6 +743,7 @@
 			"version": "0.3.13",
 			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
 			"integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.0",
@@ -753,6 +754,7 @@
 			"version": "2.3.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
 			"integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/gen-mapping": "^0.3.5",
@@ -763,6 +765,7 @@
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
 			"integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6.0.0"
@@ -772,12 +775,14 @@
 			"version": "1.5.5",
 			"resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
 			"integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@jridgewell/trace-mapping": {
 			"version": "0.3.31",
 			"resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
 			"integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/resolve-uri": "^3.1.0",
@@ -1254,6 +1259,7 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.8.tgz",
 			"integrity": "sha512-esgN+54+q0NjB0Y/4BomT9samII7jGwNy/2a3wNZbT2A2RpmXsXwUt24LvLhx6jUq2gVk4cWEvcRO6MFQbOfNA==",
+			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
 				"acorn": "^8.9.0"
@@ -2037,6 +2043,7 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
 			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@types/json-schema": {
@@ -2440,6 +2447,7 @@
 			"version": "8.15.0",
 			"resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
 			"integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
+			"dev": true,
 			"license": "MIT",
 			"bin": {
 				"acorn": "bin/acorn"
@@ -2501,6 +2509,7 @@
 			"version": "5.3.2",
 			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
 			"integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">= 0.4"
@@ -2557,6 +2566,7 @@
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
 			"integrity": "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==",
+			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">= 0.4"
@@ -2701,6 +2711,7 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
 			"integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
@@ -2836,6 +2847,7 @@
 			"version": "5.6.1",
 			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.1.tgz",
 			"integrity": "sha512-jDwizj+IlEZBunHcOuuFVBnIMPAEHvTsJj0BcIp94xYguLRVBcXO853px/MyIJvbVzWdsGvrRweIUWJw8hBP7A==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/dotenv": {
@@ -3159,6 +3171,7 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/esm-env/-/esm-env-1.2.2.tgz",
 			"integrity": "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/espree": {
@@ -3209,6 +3222,7 @@
 			"version": "2.2.1",
 			"resolved": "https://registry.npmjs.org/esrap/-/esrap-2.2.1.tgz",
 			"integrity": "sha512-GiYWG34AN/4CUyaWAgunGt0Rxvr1PTMlGC0vvEov/uOQYWne2bpN03Um+k8jT+q3op33mKouP2zeJ6OlM+qeUg==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.4.15"
@@ -3502,6 +3516,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/is-reference/-/is-reference-3.0.3.tgz",
 			"integrity": "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@types/estree": "^1.0.6"
@@ -3889,6 +3904,7 @@
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/locate-character/-/locate-character-3.0.0.tgz",
 			"integrity": "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/locate-path": {
@@ -3918,6 +3934,7 @@
 			"version": "0.30.21",
 			"resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
 			"integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/sourcemap-codec": "^1.5.5"
@@ -4798,6 +4815,7 @@
 			"version": "5.46.3",
 			"resolved": "https://registry.npmjs.org/svelte/-/svelte-5.46.3.tgz",
 			"integrity": "sha512-Y5juST3x+/ySty5tYJCVWa6Corkxpt25bUZQHqOceg9xfMUtDsFx6rCsG6cYf1cA6vzDi66HIvaki0byZZX95A==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@jridgewell/remapping": "^2.3.4",
@@ -5337,6 +5355,7 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/zimmerframe/-/zimmerframe-1.1.4.tgz",
 			"integrity": "sha512-B58NGBEoc8Y9MWWCQGl/gq9xBCe4IiKM0a2x7GZdQKOW5Exr8S1W24J6OgM1njK8xCRGvAJIL/MxXHf6SkmQKQ==",
+			"dev": true,
 			"license": "MIT"
 		}
 	}

--- a/src/lib/agent/tools.ts
+++ b/src/lib/agent/tools.ts
@@ -1,0 +1,172 @@
+/**
+ * Agent Tool Layer
+ *
+ * Exposes app capabilities as Claude tool-use API primitives.
+ * Each tool has a definition (for Claude's API) and a handler (for execution).
+ *
+ * Tool definitions follow the Claude tool-use API format:
+ * https://docs.anthropic.com/en/docs/build-with-claude/tool-use
+ */
+
+import { supabase } from '$lib/supabaseClient';
+import type { Goal, Milestone } from '$lib/types';
+
+// ---------------------------------------------------------------------------
+// Tool Definitions (Claude tool-use API format)
+// ---------------------------------------------------------------------------
+
+export interface ClaudeTool {
+	name: string;
+	description: string;
+	input_schema: {
+		type: 'object';
+		properties: Record<string, unknown>;
+		required?: string[];
+	};
+}
+
+/**
+ * get_goals — fetch all goals for a given board, authenticated to the current user.
+ *
+ * This is the first agent primitive in the tool layer and will be used by the
+ * goal suggestions feature.
+ */
+export const GET_GOALS_TOOL: ClaudeTool = {
+	name: 'get_goals',
+	description:
+		'Fetch and return all goals for a given bingo board. Only returns goals that belong to boards owned by the authenticated user. Goals include their title, notes, completion status, timestamps, and milestones.',
+	input_schema: {
+		type: 'object',
+		properties: {
+			board_id: {
+				type: 'string',
+				description: 'The UUID of the board whose goals should be fetched.'
+			}
+		},
+		required: ['board_id']
+	}
+};
+
+/** All registered agent tools, ready to pass to the Claude API. */
+export const AGENT_TOOLS: ClaudeTool[] = [GET_GOALS_TOOL];
+
+// ---------------------------------------------------------------------------
+// Tool Handlers
+// ---------------------------------------------------------------------------
+
+export interface GetGoalsInput {
+	board_id: string;
+}
+
+export interface GetGoalsResult {
+	board_id: string;
+	goals: Goal[];
+}
+
+/**
+ * get_goals handler
+ *
+ * Fetches all goals for `board_id`, enforcing ownership through Supabase RLS
+ * (the query runs with the caller's session, so only their own boards are
+ * accessible). An explicit ownership check is also performed so that a clear
+ * error is returned when the board doesn't exist or belongs to another user.
+ *
+ * @param input  Validated tool input containing `board_id`.
+ * @returns      `{ board_id, goals }` on success; throws on error.
+ */
+export async function getGoals(input: GetGoalsInput): Promise<GetGoalsResult> {
+	const { board_id } = input;
+
+	// Verify the board exists and belongs to the authenticated user.
+	// Supabase RLS will enforce this automatically, but a missing board row
+	// produces a clearer error than an empty goals array.
+	const { data: boardData, error: boardError } = await supabase
+		.from('boards')
+		.select('id')
+		.eq('id', board_id)
+		.single();
+
+	if (boardError || !boardData) {
+		throw new Error(
+			`Board not found or access denied: ${boardError?.message ?? 'no data returned'}`
+		);
+	}
+
+	// Fetch all goals for the board, ordered by position.
+	const { data: goalsData, error: goalsError } = await supabase
+		.from('goals')
+		.select(
+			`
+			id,
+			position,
+			title,
+			notes,
+			completed,
+			started_at,
+			completed_at,
+			last_updated_at,
+			created_at,
+			updated_at,
+			milestones (
+				id,
+				title,
+				notes,
+				completed,
+				completed_at,
+				created_at,
+				position
+			)
+		`
+		)
+		.eq('board_id', board_id)
+		.order('position', { ascending: true });
+
+	if (goalsError) {
+		throw new Error(`Failed to fetch goals: ${goalsError.message}`);
+	}
+
+	const goals: Goal[] = (goalsData ?? []).map((g: any) => ({
+		id: g.id,
+		title: g.title,
+		notes: g.notes ?? '',
+		completed: g.completed,
+		startedAt: g.started_at ?? null,
+		completedAt: g.completed_at ?? null,
+		lastUpdatedAt: g.last_updated_at ?? g.updated_at,
+		milestones: ((g.milestones as any[]) ?? [])
+			.sort((a: any, b: any) => a.position - b.position)
+			.map(
+				(m: any): Milestone => ({
+					id: m.id,
+					title: m.title,
+					notes: m.notes ?? '',
+					completed: m.completed,
+					completedAt: m.completed_at ?? null,
+					createdAt: m.created_at,
+					position: m.position
+				})
+			)
+	}));
+
+	return { board_id, goals };
+}
+
+// ---------------------------------------------------------------------------
+// Tool dispatcher — routes a tool_name + input to the correct handler.
+// ---------------------------------------------------------------------------
+
+/**
+ * Execute a named tool with the given input.
+ *
+ * @param toolName  The `name` field from the Claude tool-use response.
+ * @param input     The `input` field from the Claude tool-use response.
+ * @returns         Tool result (shape depends on the tool).
+ */
+export async function executeTool(toolName: string, input: unknown): Promise<unknown> {
+	switch (toolName) {
+		case 'get_goals':
+			return getGoals(input as GetGoalsInput);
+		default:
+			throw new Error(`Unknown tool: ${toolName}`);
+	}
+}

--- a/src/routes/api/agent/+server.ts
+++ b/src/routes/api/agent/+server.ts
@@ -1,0 +1,68 @@
+/**
+ * Agent Tool Execution API
+ *
+ * POST /api/agent
+ *
+ * Accepts a tool name and input, executes the corresponding agent primitive,
+ * and returns the result. Requires an authenticated Supabase session.
+ *
+ * Request body:
+ *   { tool: string; input: Record<string, unknown> }
+ *
+ * Response:
+ *   200 { result: unknown }
+ *   400 { error: string }
+ *   401 { error: string }
+ *   500 { error: string }
+ */
+
+import { json } from '@sveltejs/kit';
+import type { RequestHandler } from './$types';
+import { executeTool, AGENT_TOOLS } from '$lib/agent/tools';
+import { supabase } from '$lib/supabaseClient';
+
+export const POST: RequestHandler = async ({ request }) => {
+	// Require an authenticated session.
+	const {
+		data: { session }
+	} = await supabase.auth.getSession();
+
+	if (!session) {
+		return json({ error: 'Unauthorized: no active session' }, { status: 401 });
+	}
+
+	let body: { tool?: unknown; input?: unknown };
+	try {
+		body = await request.json();
+	} catch {
+		return json({ error: 'Invalid JSON body' }, { status: 400 });
+	}
+
+	const { tool, input } = body;
+
+	if (typeof tool !== 'string' || !tool) {
+		return json({ error: '`tool` must be a non-empty string' }, { status: 400 });
+	}
+
+	if (typeof input !== 'object' || input === null || Array.isArray(input)) {
+		return json({ error: '`input` must be a non-null object' }, { status: 400 });
+	}
+
+	try {
+		const result = await executeTool(tool, input);
+		return json({ result });
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		return json({ error: message }, { status: 500 });
+	}
+};
+
+/**
+ * GET /api/agent
+ *
+ * Returns the list of available agent tools in Claude tool-use API format.
+ * Useful for introspection and for constructing Claude API requests.
+ */
+export const GET: RequestHandler = async () => {
+	return json({ tools: AGENT_TOOLS });
+};


### PR DESCRIPTION
## Summary

Implements `get_goals(board_id)` function exposed in Claude's tool-use API format. Fetches and returns all goals for a given board, authenticated to the current user.

This is the first agent primitive in the tool layer and will be used by the goal suggestions feature.

## Changes

- **`src/lib/agent/tools.ts`** — New tool layer module:
  - `GET_GOALS_TOOL` — Claude tool-use API definition (`name`, `description`, `input_schema`)
  - `AGENT_TOOLS` — Array of all registered tools, ready to pass to the Claude API
  - `getGoals(input)` — Handler that fetches goals from Supabase, respecting RLS for auth
  - `executeTool(toolName, input)` — Dispatcher routing tool calls to their handlers
- **`src/routes/api/agent/+server.ts`** — SvelteKit API route:
  - `GET /api/agent` — Returns available tools in Claude format (for introspection)
  - `POST /api/agent` — Executes a named tool with the given input (requires session)

## Testing

Existing unit tests (`src/lib/stores/auth.test.ts`) pass: 4/4 tests green.

Fixes xsaardo/bingo#17