### PR TITLE
feat: add Buy Me a Coffee floating button

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,3 +11,8 @@ PUBLIC_SUPABASE_ANON_KEY=your-anon-key-here
 # (Optional) Service role key - only use server-side, never expose to browser
 # Only needed for admin operations or server-side API routes
 # SUPABASE_SERVICE_ROLE_KEY=your-service-role-key-here
+
+# Buy Me a Coffee integration
+# Set to your buymeacoffee.com profile URL to enable the floating button
+# Example: https://buymeacoffee.com/yourusername
+PUBLIC_BMC_URL=https://buymeacoffee.com/xsaardo

--- a/src/lib/components/AuthGuard.svelte
+++ b/src/lib/components/AuthGuard.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
+	import BuyMeACoffee from '$lib/components/BuyMeACoffee.svelte';
 	import { goto } from '$app/navigation';
 	import { browser } from '$app/environment';
 	import { authError, authStore, isAuthenticated, isAuthInitialized, isAuthLoading } from '$lib/stores/auth';
@@ -80,6 +81,7 @@
 	</div>
 {:else if shouldRender}
 	<!-- Render protected content -->
+	<BuyMeACoffee />
 	<slot />
 {:else}
 	<!-- Redirecting to login (don't render anything) -->

--- a/src/lib/components/BuyMeACoffee.svelte
+++ b/src/lib/components/BuyMeACoffee.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import { env } from '$env/dynamic/public';
+
+	const bmcUrl = env.PUBLIC_BMC_URL;
+</script>
+
+{#if bmcUrl}
+	<a
+		href={bmcUrl}
+		target="_blank"
+		rel="noopener noreferrer"
+		class="fixed bottom-6 right-6 z-50 flex items-center gap-2 rounded-full bg-yellow-400 px-4 py-3 text-sm font-semibold text-gray-900 shadow-lg transition-transform hover:scale-105 hover:bg-yellow-300 focus:outline-none focus:ring-2 focus:ring-yellow-500 focus:ring-offset-2"
+		aria-label="Buy me a coffee"
+	>
+		<span class="text-lg">☕</span>
+		<span>Buy me a coffee</span>
+	</a>
+{/if}


### PR DESCRIPTION
## Summary

Adds a floating Buy Me a Coffee button to all authenticated pages.

## Changes

- Added `src/lib/components/BuyMeACoffee.svelte` floating button component
- Integrated into authenticated layout via `AuthGuard.svelte`
- Added `PUBLIC_BMC_URL` to `.env.example`
- Button hidden if env var not configured

## Testing

Existing tests pass. Component renders correctly when `PUBLIC_BMC_URL` is set.

Fixes xsaardo/bingo#20