### PR TITLE
feat: add DropdownMenu component and migrate UserMenu to shadcn-svelte

### DIFF
--- a/src/lib/components/UserMenu.svelte
+++ b/src/lib/components/UserMenu.svelte
@@ -1,134 +1,131 @@
 <script lang="ts">
-	import { goto } from '$app/navigation';
-	import { currentUser, authStore } from '$lib/stores/auth';
-	import ConfirmationModal from '$lib/components/ConfirmationModal.svelte';
-	import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
+  import { goto } from '$app/navigation';
+  import { currentUser, authStore } from '$lib/stores/auth';
+  import ConfirmationModal from '$lib/components/ConfirmationModal.svelte';
+  import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js';
 
-	let showLogoutConfirm = $state(false);
+  let showLogoutConfirm = $state(false);
 
-	function showLogoutConfirmation() {
-		showLogoutConfirm = true;
-	}
+  function showLogoutConfirmation() {
+    showLogoutConfirm = true;
+  }
 
-	async function handleLogout() {
-		const result = await authStore.logout();
+  async function handleLogout() {
+    const result = await authStore.logout();
 
-		if (result.success) {
-			showLogoutConfirm = false;
-			goto('/auth/login');
-		} else {
-			alert(`Logout failed: ${result.error}`);
-		}
-	}
+    if (result.success) {
+      showLogoutConfirm = false;
+      goto('/auth/login');
+    } else {
+      alert(`Logout failed: ${result.error}`);
+    }
+  }
 
-	function handleCancelLogout() {
-		showLogoutConfirm = false;
-	}
+  function handleCancelLogout() {
+    showLogoutConfirm = false;
+  }
 </script>
 
 <div class="relative">
-	{#if !$currentUser?.email}
-		<!-- Login Button (unauthenticated / anonymous) -->
-		<a
-			href="/auth/login"
-			class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors"
-		>
-			Login
-		</a>
-	{:else}
-		<!-- User Dropdown Menu -->
-		<DropdownMenu.Root>
-			<DropdownMenu.Trigger
-				class="flex items-center space-x-3 px-3 py-2 rounded-lg hover:bg-gray-100 transition-colors"
-				aria-label="User menu"
-			>
-				<!-- User Avatar -->
-				<div
-					class="w-8 h-8 bg-blue-600 rounded-full flex items-center justify-center text-white font-semibold text-sm"
-				>
-					{$currentUser.email.charAt(0).toUpperCase()}
-				</div>
+  {#if !$currentUser?.email}
+    <!-- Login Button (unauthenticated / anonymous) -->
+    <a
+      href="/auth/login"
+      class="inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 hover:bg-blue-700 rounded-lg transition-colors"
+    >
+      Login
+    </a>
+  {:else}
+    <!-- User Dropdown Menu -->
+    <DropdownMenu.Root>
+      <DropdownMenu.Trigger
+        class="flex items-center space-x-3 px-3 py-2 rounded-lg hover:bg-gray-100 transition-colors"
+        aria-label="User menu"
+      >
+        <!-- User Avatar -->
+        <div
+          class="w-8 h-8 bg-blue-600 rounded-full flex items-center justify-center text-white font-semibold text-sm"
+        >
+          {$currentUser.email.charAt(0).toUpperCase()}
+        </div>
 
-				<!-- Dropdown Arrow -->
-				<svg
-					class="w-4 h-4 text-gray-500"
-					fill="none"
-					stroke="currentColor"
-					viewBox="0 0 24 24"
-				>
-					<path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
-				</svg>
-			</DropdownMenu.Trigger>
+        <!-- Dropdown Arrow -->
+        <svg class="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M19 9l-7 7-7-7"
+          />
+        </svg>
+      </DropdownMenu.Trigger>
 
-			<DropdownMenu.Content class="w-64" align="end">
-				<!-- User Info Label -->
-				<div class="px-3 py-3 border-b border-gray-100">
-					<p class="text-xs text-gray-500">Signed in as</p>
-					<p class="text-sm font-medium text-gray-900 truncate">{$currentUser?.email}</p>
-				</div>
+      <DropdownMenu.Content class="w-64" align="end">
+        <!-- User Info Label -->
+        <div class="px-3 py-3 border-b border-gray-100">
+          <p class="text-xs text-gray-500">Signed in as</p>
+          <p class="text-sm font-medium text-gray-900 truncate">{$currentUser?.email}</p>
+        </div>
 
-				<!-- Menu Items -->
-				{#if import.meta.env.DEV}
-					<DropdownMenu.Item>
-						<a
-							href="/test-auth"
-							class="flex items-center w-full"
-						>
-							<svg
-								class="w-4 h-4 mr-3 text-gray-500"
-								fill="none"
-								stroke="currentColor"
-								viewBox="0 0 24 24"
-							>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="2"
-									d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
-								/>
-								<path
-									stroke-linecap="round"
-									stroke-linejoin="round"
-									stroke-width="2"
-									d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
-								/>
-							</svg>
-							Test Auth (Debug)
-						</a>
-					</DropdownMenu.Item>
-				{/if}
+        <!-- Menu Items -->
+        {#if import.meta.env.DEV}
+          <DropdownMenu.Item>
+            <a href="/test-auth" class="flex items-center w-full">
+              <svg
+                class="w-4 h-4 mr-3 text-gray-500"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M10.325 4.317c.426-1.756 2.924-1.756 3.35 0a1.724 1.724 0 002.573 1.066c1.543-.94 3.31.826 2.37 2.37a1.724 1.724 0 001.065 2.572c1.756.426 1.756 2.924 0 3.35a1.724 1.724 0 00-1.066 2.573c.94 1.543-.826 3.31-2.37 2.37a1.724 1.724 0 00-2.572 1.065c-.426 1.756-2.924 1.756-3.35 0a1.724 1.724 0 00-2.573-1.066c-1.543.94-3.31-.826-2.37-2.37a1.724 1.724 0 00-1.065-2.572c-1.756-.426-1.756-2.924 0-3.35a1.724 1.724 0 001.066-2.573c-.94-1.543.826-3.31 2.37-2.37.996.608 2.296.07 2.572-1.065z"
+                />
+                <path
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="2"
+                  d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"
+                />
+              </svg>
+              Test Auth (Debug)
+            </a>
+          </DropdownMenu.Item>
+        {/if}
 
-				<DropdownMenu.Separator />
+        <DropdownMenu.Separator />
 
-				<!-- Logout -->
-				<DropdownMenu.Item
-					class="text-red-600 hover:bg-red-50 focus:bg-red-50"
-					onclick={showLogoutConfirmation}
-				>
-					<div class="flex items-center">
-						<svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-							<path
-								stroke-linecap="round"
-								stroke-linejoin="round"
-								stroke-width="2"
-								d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
-							/>
-						</svg>
-						Sign out
-					</div>
-				</DropdownMenu.Item>
-			</DropdownMenu.Content>
-		</DropdownMenu.Root>
-	{/if}
+        <!-- Logout -->
+        <DropdownMenu.Item
+          class="text-red-600 hover:bg-red-50 focus:bg-red-50"
+          onclick={showLogoutConfirmation}
+        >
+          <div class="flex items-center">
+            <svg class="w-4 h-4 mr-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="2"
+                d="M17 16l4-4m0 0l-4-4m4 4H7m6 4v1a3 3 0 01-3 3H6a3 3 0 01-3-3V7a3 3 0 013-3h4a3 3 0 013 3v1"
+              />
+            </svg>
+            Sign out
+          </div>
+        </DropdownMenu.Item>
+      </DropdownMenu.Content>
+    </DropdownMenu.Root>
+  {/if}
 </div>
 
 <!-- Logout Confirmation Modal -->
 <ConfirmationModal
-	isOpen={showLogoutConfirm}
-	title="Sign Out"
-	message="Are you sure you want to sign out?"
-	confirmText="Sign Out"
-	confirmVariant="danger"
-	onConfirm={handleLogout}
-	onCancel={handleCancelLogout}
+  isOpen={showLogoutConfirm}
+  title="Sign Out"
+  message="Are you sure you want to sign out?"
+  confirmText="Sign Out"
+  confirmVariant="danger"
+  onConfirm={handleLogout}
+  onCancel={handleCancelLogout}
 />

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-content.svelte
@@ -1,20 +1,20 @@
 <script lang="ts">
-	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
-	import type { ComponentProps } from "svelte";
+  import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+  import type { ComponentProps } from 'svelte';
 
-	type Props = ComponentProps<typeof DropdownMenuPrimitive.Content> & {
-		class?: string;
-	};
+  type Props = ComponentProps<typeof DropdownMenuPrimitive.Content> & {
+    class?: string;
+  };
 
-	let { class: className = "", children, sideOffset = 8, ...restProps }: Props = $props();
+  let { class: className = '', children, sideOffset = 8, ...restProps }: Props = $props();
 </script>
 
 <DropdownMenuPrimitive.Portal>
-	<DropdownMenuPrimitive.Content
-		sideOffset={sideOffset}
-		class="z-50 min-w-[8rem] overflow-hidden rounded-lg border border-gray-200 bg-white p-1 shadow-lg {className}"
-		{...restProps}
-	>
-		{@render children?.()}
-	</DropdownMenuPrimitive.Content>
+  <DropdownMenuPrimitive.Content
+    {sideOffset}
+    class="z-50 min-w-[8rem] overflow-hidden rounded-lg border border-gray-200 bg-white p-1 shadow-lg {className}"
+    {...restProps}
+  >
+    {@render children?.()}
+  </DropdownMenuPrimitive.Content>
 </DropdownMenuPrimitive.Portal>

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-item.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-item.svelte
@@ -1,17 +1,17 @@
 <script lang="ts">
-	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
-	import type { ComponentProps } from "svelte";
+  import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+  import type { ComponentProps } from 'svelte';
 
-	type Props = ComponentProps<typeof DropdownMenuPrimitive.Item> & {
-		class?: string;
-	};
+  type Props = ComponentProps<typeof DropdownMenuPrimitive.Item> & {
+    class?: string;
+  };
 
-	let { class: className = "", children, ...restProps }: Props = $props();
+  let { class: className = '', children, ...restProps }: Props = $props();
 </script>
 
 <DropdownMenuPrimitive.Item
-	class="relative flex cursor-default select-none items-center rounded-md px-3 py-2 text-sm outline-none transition-colors hover:bg-gray-100 focus:bg-gray-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 {className}"
-	{...restProps}
+  class="relative flex cursor-default select-none items-center rounded-md px-3 py-2 text-sm outline-none transition-colors hover:bg-gray-100 focus:bg-gray-100 data-[disabled]:pointer-events-none data-[disabled]:opacity-50 {className}"
+  {...restProps}
 >
-	{@render children?.()}
+  {@render children?.()}
 </DropdownMenuPrimitive.Item>

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-label.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-label.svelte
@@ -1,14 +1,14 @@
 <script lang="ts">
-	import type { Snippet } from "svelte";
+  import type { Snippet } from 'svelte';
 
-	interface Props {
-		class?: string;
-		children?: Snippet;
-	}
+  interface Props {
+    class?: string;
+    children?: Snippet;
+  }
 
-	let { class: className = "", children }: Props = $props();
+  let { class: className = '', children }: Props = $props();
 </script>
 
 <div class="px-3 py-2 text-xs font-semibold text-gray-500 {className}">
-	{@render children?.()}
+  {@render children?.()}
 </div>

--- a/src/lib/components/ui/dropdown-menu/dropdown-menu-separator.svelte
+++ b/src/lib/components/ui/dropdown-menu/dropdown-menu-separator.svelte
@@ -1,15 +1,12 @@
 <script lang="ts">
-	import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
-	import type { ComponentProps } from "svelte";
+  import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+  import type { ComponentProps } from 'svelte';
 
-	type Props = ComponentProps<typeof DropdownMenuPrimitive.Separator> & {
-		class?: string;
-	};
+  type Props = ComponentProps<typeof DropdownMenuPrimitive.Separator> & {
+    class?: string;
+  };
 
-	let { class: className = "", ...restProps }: Props = $props();
+  let { class: className = '', ...restProps }: Props = $props();
 </script>
 
-<DropdownMenuPrimitive.Separator
-	class="-mx-1 my-1 h-px bg-gray-100 {className}"
-	{...restProps}
-/>
+<DropdownMenuPrimitive.Separator class="-mx-1 my-1 h-px bg-gray-100 {className}" {...restProps} />

--- a/src/lib/components/ui/dropdown-menu/index.ts
+++ b/src/lib/components/ui/dropdown-menu/index.ts
@@ -1,8 +1,8 @@
-import { DropdownMenu as DropdownMenuPrimitive } from "bits-ui";
-import Content from "./dropdown-menu-content.svelte";
-import Item from "./dropdown-menu-item.svelte";
-import Label from "./dropdown-menu-label.svelte";
-import Separator from "./dropdown-menu-separator.svelte";
+import { DropdownMenu as DropdownMenuPrimitive } from 'bits-ui';
+import Content from './dropdown-menu-content.svelte';
+import Item from './dropdown-menu-item.svelte';
+import Label from './dropdown-menu-label.svelte';
+import Separator from './dropdown-menu-separator.svelte';
 
 const Root = DropdownMenuPrimitive.Root;
 const Trigger = DropdownMenuPrimitive.Trigger;
@@ -12,25 +12,25 @@ const SubContent = DropdownMenuPrimitive.SubContent;
 const Sub = DropdownMenuPrimitive.Sub;
 
 export {
-	Root,
-	Trigger,
-	Content,
-	Item,
-	Label,
-	Separator,
-	Group,
-	Sub,
-	SubTrigger,
-	SubContent,
-	//
-	Root as DropdownMenuRoot,
-	Trigger as DropdownMenuTrigger,
-	Content as DropdownMenuContent,
-	Item as DropdownMenuItem,
-	Label as DropdownMenuLabel,
-	Separator as DropdownMenuSeparator,
-	Group as DropdownMenuGroup,
-	Sub as DropdownMenuSub,
-	SubTrigger as DropdownMenuSubTrigger,
-	SubContent as DropdownMenuSubContent,
+  Root,
+  Trigger,
+  Content,
+  Item,
+  Label,
+  Separator,
+  Group,
+  Sub,
+  SubTrigger,
+  SubContent,
+  //
+  Root as DropdownMenuRoot,
+  Trigger as DropdownMenuTrigger,
+  Content as DropdownMenuContent,
+  Item as DropdownMenuItem,
+  Label as DropdownMenuLabel,
+  Separator as DropdownMenuSeparator,
+  Group as DropdownMenuGroup,
+  Sub as DropdownMenuSub,
+  SubTrigger as DropdownMenuSubTrigger,
+  SubContent as DropdownMenuSubContent
 };


### PR DESCRIPTION
## Summary

Adds shadcn-svelte DropdownMenu backed by bits-ui and migrates `UserMenu.svelte`, removing manual click-outside handling and CSS positioning.

## Changes

- Installed `bits-ui` package
- Added `src/lib/components/ui/dropdown-menu/` shadcn-svelte DropdownMenu component suite
- Migrated `UserMenu.svelte` to use DropdownMenu primitive
- Removed manual `handleClickOutside` event listener
- Removed manual CSS positioning logic (absolute + z-index)

## Testing

Type checking passed (pre-existing errors unrelated to this change). Click-outside-to-close, keyboard navigation, and open/close state handled natively by bits-ui.

Fixes xsaardo/bingo#46