### PR TITLE
security: add dependency-review-action to block vulnerable deps in PRs

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,8 @@
+name: Dependency Review
+on: [pull_request]
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/dependency-review-action@v4


### PR DESCRIPTION
## Summary

Adds the `dependency-review-action` GitHub Action workflow to automatically scan PRs for newly introduced dependencies with known vulnerabilities.

## Changes

- Added `.github/workflows/dependency-review.yml` that runs on every pull request
- Uses `actions/checkout@v4` and `actions/dependency-review-action@v4`
- Any PR introducing a dependency with a known CVE will be flagged before merge

Fixes #59