### PR TITLE
ui: Add Badge component and replace inline badge spans

### DIFF
--- a/src/lib/components/BoardCard.svelte
+++ b/src/lib/components/BoardCard.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
   import type { Board } from '$lib/types';
   import { boardsStore } from '$lib/stores/boards';
+  import { Badge } from '$lib/components/ui/badge';
 
   interface Props {
     board: Board;
@@ -223,10 +224,8 @@
     <div class="flex items-center justify-between">
       <div class="flex items-center space-x-2">
         {#if !hasContent}
-          <span
-            class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800"
-          >
-            <svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <Badge variant="secondary">
+            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path
                 stroke-linecap="round"
                 stroke-linejoin="round"
@@ -235,12 +234,10 @@
               />
             </svg>
             Empty
-          </span>
+          </Badge>
         {:else if completedGoals === totalGoals}
-          <span
-            class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800"
-          >
-            <svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <Badge variant="outline" class="border-green-500 bg-green-50 text-green-700">
+            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path
                 stroke-linecap="round"
                 stroke-linejoin="round"
@@ -249,12 +246,10 @@
               />
             </svg>
             Complete
-          </span>
+          </Badge>
         {:else if completedGoals > 0}
-          <span
-            class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800"
-          >
-            <svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <Badge variant="outline" class="border-blue-400 bg-blue-50 text-blue-700">
+            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path
                 stroke-linecap="round"
                 stroke-linejoin="round"
@@ -263,12 +258,10 @@
               />
             </svg>
             In Progress
-          </span>
+          </Badge>
         {:else}
-          <span
-            class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-yellow-100 text-yellow-800"
-          >
-            <svg class="w-3 h-3 mr-1" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <Badge variant="outline" class="border-yellow-400 bg-yellow-50 text-yellow-700">
+            <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path
                 stroke-linecap="round"
                 stroke-linejoin="round"
@@ -277,7 +270,7 @@
               />
             </svg>
             Not Started
-          </span>
+          </Badge>
         {/if}
       </div>
 

--- a/src/lib/components/ui/badge/badge.svelte
+++ b/src/lib/components/ui/badge/badge.svelte
@@ -1,0 +1,49 @@
+<script lang="ts" module>
+  import { type VariantProps, tv } from 'tailwind-variants';
+
+  export const badgeVariants = tv({
+    base: 'focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive inline-flex w-fit shrink-0 items-center justify-center gap-1 overflow-hidden rounded-full border px-2 py-0.5 text-xs font-medium whitespace-nowrap transition-[color,box-shadow] focus-visible:ring-[3px] [&>svg]:pointer-events-none [&>svg]:size-3',
+    variants: {
+      variant: {
+        default: 'bg-primary text-primary-foreground [a&]:hover:bg-primary/90 border-transparent',
+        secondary:
+          'bg-secondary text-secondary-foreground [a&]:hover:bg-secondary/90 border-transparent',
+        destructive:
+          'bg-destructive [a&]:hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/70 border-transparent text-white',
+        outline: 'text-foreground [a&]:hover:bg-accent [a&]:hover:text-accent-foreground'
+      }
+    },
+    defaultVariants: {
+      variant: 'default'
+    }
+  });
+
+  export type BadgeVariant = VariantProps<typeof badgeVariants>['variant'];
+</script>
+
+<script lang="ts">
+  import type { HTMLAnchorAttributes } from 'svelte/elements';
+  import { cn, type WithElementRef } from '$lib/utils.js';
+
+  let {
+    ref = $bindable(null),
+    href,
+    class: className,
+    variant = 'default',
+    children,
+    ...restProps
+  }: WithElementRef<HTMLAnchorAttributes> & {
+    variant?: BadgeVariant;
+  } = $props();
+</script>
+
+<svelte:element
+  this={href ? 'a' : 'span'}
+  bind:this={ref}
+  data-slot="badge"
+  {href}
+  class={cn(badgeVariants({ variant }), className)}
+  {...restProps}
+>
+  {@render children?.()}
+</svelte:element>

--- a/src/lib/components/ui/badge/index.ts
+++ b/src/lib/components/ui/badge/index.ts
@@ -1,0 +1,2 @@
+export { default as Badge } from './badge.svelte';
+export { badgeVariants, type BadgeVariant } from './badge.svelte';


### PR DESCRIPTION
## Summary

Adds the shadcn-svelte `Badge` component and replaces the four inline `<span>` badge elements in `BoardCard.svelte`.

## Changes

- **New:** `src/lib/components/ui/badge/badge.svelte` — shadcn-svelte Badge component
- **New:** `src/lib/components/ui/badge/index.ts` — exports
- **Modified:** `src/lib/components/BoardCard.svelte` — replaced inline badge spans with `<Badge>` component

## Badge Variant Mapping

| Status | Variant | Styling |
|--------|---------|--------|
| Empty | `secondary` | Gray (default secondary) |
| Complete | `outline` | Green border/background |
| In Progress | `outline` | Blue border/background |
| Not Started | `outline` | Yellow border/background |

## Notes

- Branched from `main` (shadcn was already initialized via #39)
- Build error for missing Supabase env vars is pre-existing and unrelated to these changes
- All SVG icons preserved inside Badge components

Fixes #43