### PR TITLE
fix: graceful text truncation in bingo squares

### DIFF
--- a/src/lib/components/GoalSquare.svelte
+++ b/src/lib/components/GoalSquare.svelte
@@ -76,7 +76,7 @@
     <div class="flex-1 flex items-center justify-center text-center px-1 overflow-hidden min-h-0">
       {#if goal.title}
         <p
-          class="{titleTextClass} font-medium line-clamp-3 {goal.completed
+          class="{titleTextClass} font-medium line-clamp-3 break-words w-full {goal.completed
             ? 'text-green-900'
             : 'text-gray-900'}"
         >


### PR DESCRIPTION
## Summary

Fixes mid-word text truncation in bingo goal squares. Text now wraps cleanly within the square and truncates with an ellipsis after 3 lines, rather than clipping mid-character.

## Changes

- Added `break-words` and `w-full` Tailwind classes to the goal title `<p>` element in `GoalSquare.svelte`
- `break-words` (`overflow-wrap: break-word`) ensures long words wrap at word boundaries instead of overflowing the container horizontally
- `w-full` ensures the paragraph fills the flex container width so clamping works correctly
- The existing `line-clamp-3` already provides ellipsis truncation after 3 lines; this fix addresses the horizontal clipping issue

## Testing

Visually verified that longer goal titles (e.g. "Contribute to open source", "Buy Chanel a big gift", "Release monetized app") display cleanly without mid-word horizontal clipping.

Fixes xsaardo/bingo#57