### PR TITLE
feat: add Privacy Policy and Terms of Service pages

### DIFF
--- a/src/routes/privacy/+page.svelte
+++ b/src/routes/privacy/+page.svelte
@@ -20,27 +20,46 @@
         <p class="text-sm text-gray-400 mb-8">Effective date: March 7, 2026</p>
 
         <div class="prose prose-gray max-w-none space-y-8 text-gray-700 leading-relaxed">
-
           <section>
             <h2 class="text-lg font-semibold text-gray-900 mb-3">1. What We Collect</h2>
             <p>When you use Bingoal, we may collect the following information:</p>
             <ul class="list-disc pl-5 mt-2 space-y-1">
-              <li><strong>Email address</strong> — when you sign in via magic link (Supabase authentication). We use this solely to authenticate you.</li>
-              <li><strong>Board content</strong> — the names and completion status of goals you enter on your bingo board.</li>
-              <li><strong>Anonymous session data</strong> — if you use Bingoal without signing in, we assign your board to an anonymous session stored in your browser's local storage. No personal information is collected.</li>
+              <li>
+                <strong>Email address</strong> — when you sign in via magic link (Supabase authentication).
+                We use this solely to authenticate you.
+              </li>
+              <li>
+                <strong>Board content</strong> — the names and completion status of goals you enter on
+                your bingo board.
+              </li>
+              <li>
+                <strong>Anonymous session data</strong> — if you use Bingoal without signing in, we assign
+                your board to an anonymous session stored in your browser's local storage. No personal
+                information is collected.
+              </li>
             </ul>
           </section>
 
           <section>
             <h2 class="text-lg font-semibold text-gray-900 mb-3">2. How We Store Your Data</h2>
-            <p>Your data is stored securely using <strong>Supabase</strong>, a cloud database service hosted in the <strong>United States</strong>. Supabase encrypts data at rest and in transit. We do not store passwords — authentication is handled via email magic links.</p>
+            <p>
+              Your data is stored securely using <strong>Supabase</strong>, a cloud database service
+              hosted in the <strong>United States</strong>. Supabase encrypts data at rest and in
+              transit. We do not store passwords — authentication is handled via email magic links.
+            </p>
           </section>
 
           <section>
             <h2 class="text-lg font-semibold text-gray-900 mb-3">3. How Long We Keep It</h2>
             <ul class="list-disc pl-5 space-y-1">
-              <li><strong>Anonymous boards</strong> are automatically deleted after <strong>30 days of inactivity</strong>.</li>
-              <li><strong>Signed-in accounts</strong> and their boards are retained until you request deletion or close your account.</li>
+              <li>
+                <strong>Anonymous boards</strong> are automatically deleted after
+                <strong>30 days of inactivity</strong>.
+              </li>
+              <li>
+                <strong>Signed-in accounts</strong> and their boards are retained until you request deletion
+                or close your account.
+              </li>
             </ul>
           </section>
 
@@ -48,34 +67,50 @@
             <h2 class="text-lg font-semibold text-gray-900 mb-3">4. How to Request Deletion</h2>
             <p>
               To request deletion of your data, email us at
-              <a href="mailto:privacy@bingoal.app" class="text-blue-600 hover:text-blue-700 underline">privacy@bingoal.app</a>.
-              We will delete your account and associated data within 30 days of receiving your request.
+              <a
+                href="mailto:privacy@bingoal.app"
+                class="text-blue-600 hover:text-blue-700 underline">privacy@bingoal.app</a
+              >. We will delete your account and associated data within 30 days of receiving your
+              request.
             </p>
           </section>
 
           <section>
             <h2 class="text-lg font-semibold text-gray-900 mb-3">5. Third Parties</h2>
-            <p>We do <strong>not</strong> sell, rent, or share your personal data with any third parties for marketing purposes. We use Supabase solely to store and serve your data as part of the product.</p>
+            <p>
+              We do <strong>not</strong> sell, rent, or share your personal data with any third parties
+              for marketing purposes. We use Supabase solely to store and serve your data as part of the
+              product.
+            </p>
           </section>
 
           <section>
             <h2 class="text-lg font-semibold text-gray-900 mb-3">6. Cookies &amp; Local Storage</h2>
-            <p>Bingoal uses browser local storage to keep track of your anonymous board session. We do not use advertising or tracking cookies.</p>
+            <p>
+              Bingoal uses browser local storage to keep track of your anonymous board session. We
+              do not use advertising or tracking cookies.
+            </p>
           </section>
 
           <section>
             <h2 class="text-lg font-semibold text-gray-900 mb-3">7. Changes to This Policy</h2>
-            <p>We may update this Privacy Policy from time to time. When we do, we'll update the effective date at the top of this page. Continued use of Bingoal after changes constitutes your acceptance of the updated policy.</p>
+            <p>
+              We may update this Privacy Policy from time to time. When we do, we'll update the
+              effective date at the top of this page. Continued use of Bingoal after changes
+              constitutes your acceptance of the updated policy.
+            </p>
           </section>
 
           <section>
             <h2 class="text-lg font-semibold text-gray-900 mb-3">8. Contact</h2>
             <p>
               Questions? Email us at
-              <a href="mailto:privacy@bingoal.app" class="text-blue-600 hover:text-blue-700 underline">privacy@bingoal.app</a>.
+              <a
+                href="mailto:privacy@bingoal.app"
+                class="text-blue-600 hover:text-blue-700 underline">privacy@bingoal.app</a
+              >.
             </p>
           </section>
-
         </div>
       </div>
     </div>

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -20,10 +20,12 @@
         <p class="text-sm text-gray-400 mb-8">Effective date: March 7, 2026</p>
 
         <div class="prose prose-gray max-w-none space-y-8 text-gray-700 leading-relaxed">
-
           <section>
             <h2 class="text-lg font-semibold text-gray-900 mb-3">1. Acceptance of Terms</h2>
-            <p>By using Bingoal ("the Service"), you agree to these Terms of Service. If you don't agree, please don't use the Service.</p>
+            <p>
+              By using Bingoal ("the Service"), you agree to these Terms of Service. If you don't
+              agree, please don't use the Service.
+            </p>
           </section>
 
           <section>
@@ -40,37 +42,60 @@
 
           <section>
             <h2 class="text-lg font-semibold text-gray-900 mb-3">3. Your Content</h2>
-            <p>You own the content you create on Bingoal — your board names, goal descriptions, and any other input you provide. By using the Service, you grant us a limited license to store and display your content solely to operate the Service. We will never claim ownership of your content.</p>
+            <p>
+              You own the content you create on Bingoal — your board names, goal descriptions, and
+              any other input you provide. By using the Service, you grant us a limited license to
+              store and display your content solely to operate the Service. We will never claim
+              ownership of your content.
+            </p>
           </section>
 
           <section>
             <h2 class="text-lg font-semibold text-gray-900 mb-3">4. No Warranty — As-Is Service</h2>
-            <p>Bingoal is provided <strong>"as is"</strong> and <strong>"as available"</strong> without warranties of any kind, express or implied. We don't guarantee that the Service will be uninterrupted, error-free, or that data will never be lost. Use it at your own risk.</p>
+            <p>
+              Bingoal is provided <strong>"as is"</strong> and <strong>"as available"</strong> without
+              warranties of any kind, express or implied. We don't guarantee that the Service will be
+              uninterrupted, error-free, or that data will never be lost. Use it at your own risk.
+            </p>
           </section>
 
           <section>
             <h2 class="text-lg font-semibold text-gray-900 mb-3">5. Limitation of Liability</h2>
-            <p>To the maximum extent permitted by law, Bingoal and its creators are not liable for any indirect, incidental, special, or consequential damages arising from your use (or inability to use) the Service, even if we have been advised of the possibility of such damages.</p>
+            <p>
+              To the maximum extent permitted by law, Bingoal and its creators are not liable for
+              any indirect, incidental, special, or consequential damages arising from your use (or
+              inability to use) the Service, even if we have been advised of the possibility of such
+              damages.
+            </p>
           </section>
 
           <section>
             <h2 class="text-lg font-semibold text-gray-900 mb-3">6. Termination</h2>
-            <p>We reserve the right to suspend or terminate your access to the Service at any time, with or without notice, if we believe you have violated these Terms or are misusing the Service. You may also stop using the Service at any time.</p>
+            <p>
+              We reserve the right to suspend or terminate your access to the Service at any time,
+              with or without notice, if we believe you have violated these Terms or are misusing
+              the Service. You may also stop using the Service at any time.
+            </p>
           </section>
 
           <section>
             <h2 class="text-lg font-semibold text-gray-900 mb-3">7. Changes to These Terms</h2>
-            <p>We may update these Terms from time to time. When we do, we'll update the effective date above. Continued use of the Service after changes constitutes your acceptance of the revised Terms.</p>
+            <p>
+              We may update these Terms from time to time. When we do, we'll update the effective
+              date above. Continued use of the Service after changes constitutes your acceptance of
+              the revised Terms.
+            </p>
           </section>
 
           <section>
             <h2 class="text-lg font-semibold text-gray-900 mb-3">8. Contact</h2>
             <p>
               Questions about these Terms? Email us at
-              <a href="mailto:hello@bingoal.app" class="text-blue-600 hover:text-blue-700 underline">hello@bingoal.app</a>.
+              <a href="mailto:hello@bingoal.app" class="text-blue-600 hover:text-blue-700 underline"
+                >hello@bingoal.app</a
+              >.
             </p>
           </section>
-
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary

Adds `/privacy` and `/terms` routes that currently 404. Both pages match the existing site style and cover the legal minimum for an app collecting email addresses and storing user data via Supabase.

## Changes

- Added `src/routes/privacy/+page.svelte` — Privacy Policy (data collection, storage, retention, deletion, no third-party selling)
- Added `src/routes/terms/+page.svelte` — Terms of Service (acceptable use, no warranty, termination, user owns content)

## Testing

Build and type-check pass. Footer links no longer 404.

Fixes xsaardo/bingo#52