### PR TITLE
test: replace waitForTimeout sleeps with event-driven waits (issue #79)

### DIFF
--- a/tests/goals.spec.ts
+++ b/tests/goals.spec.ts
@@ -142,18 +142,20 @@ test.describe('Goal completion', () => {
     const titleInput = page.locator('input').first();
     await titleInput.fill('Test Goal Title');
 
-    // Save and close
+    // Save and wait for modal to close
     await page.getByTestId('save-goal-button').click();
-    await page.waitForTimeout(200);
+    await expect(page.getByTestId('goal-modal')).not.toBeVisible();
 
     // Verify title is displayed
     await expect(page.locator('text=Test Goal Title').first()).toBeVisible();
 
-    // Toggle completion
+    // Toggle completion — watch for the PATCH response to confirm the update was persisted
+    const completionResponse = page.waitForResponse(
+      (resp) => resp.url().includes('/goals') && resp.request().method() === 'PATCH',
+      { timeout: 5000 }
+    );
     await page.getByTestId('goal-square').first().getByTestId('goal-checkbox').click();
-
-    // Wait for update
-    await page.waitForTimeout(300);
+    await completionResponse;
 
     // Verify completed styling
     const goalSquare = page.getByTestId('goal-square').first();
@@ -176,19 +178,22 @@ test.describe('Goal completion', () => {
       await page.waitForSelector('[data-testid="goal-modal"]');
       // Use click() instead of check() — checkbox is async/controlled; check() can't verify state change
       await page.getByTestId('modal-checkbox').click();
-      await page.waitForTimeout(200);
       await page.getByTestId('save-goal-button').click();
       await expect(page.getByTestId('goal-modal')).not.toBeVisible();
     }
 
-    // Confetti or bingo indicator should appear
+    // Confetti or bingo indicator should appear — wait for any matching element
+    await page
+      .waitForSelector(
+        '[data-testid="bingo-confetti"], [class*="confetti"], [data-testid="bingo-indicator"], [class*="bingo"]',
+        { timeout: 5000 }
+      )
+      .catch(() => {});
+
+    // Either a visual confetti element appeared, or the board shows a bingo indicator
     const confetti = page
       .locator('[data-testid="bingo-confetti"], [class*="confetti"], canvas')
       .first();
-    // Allow some time for animation to trigger
-    await page.waitForTimeout(500);
-
-    // Either a visual confetti element appeared, or the board shows a bingo indicator
     const bingoIndicator = page
       .locator('[data-testid="bingo-indicator"], [class*="bingo"]')
       .first();

--- a/tests/milestones.spec.ts
+++ b/tests/milestones.spec.ts
@@ -86,9 +86,9 @@ test.describe('updateMilestone', () => {
     await expandGoalModal(page);
     await addMilestone(page, 'Original Title');
 
-    // Expand milestone by clicking the row
+    // Expand milestone by clicking the row and wait for the title input to appear
     await page.getByTestId('milestone-item').click();
-    await page.waitForTimeout(200);
+    await page.waitForSelector('input[placeholder="Milestone title..."]', { timeout: 3000 });
 
     // Edit title and wait for the debounced save to reach the server
     const titleInput = page.locator('input[placeholder="Milestone title..."]');
@@ -111,10 +111,14 @@ test.describe('toggleMilestoneComplete', () => {
     await expandGoalModal(page);
     await addMilestone(page, 'Test Milestone');
 
-    // Click milestone checkbox
+    // Click milestone checkbox and wait for the PATCH to confirm persistence
     const milestoneCheckbox = page.getByTestId('milestone-checkbox');
+    const markCompleteResponse = page.waitForResponse(
+      (resp) => resp.url().includes('/milestones') && resp.request().method() === 'PATCH',
+      { timeout: 5000 }
+    );
     await milestoneCheckbox.click();
-    await page.waitForTimeout(300);
+    await markCompleteResponse;
 
     const milestoneData = await getMilestoneForGoal(page, firstGoalId, 'completed, completed_at');
     expect(milestoneData?.completed).toBe(true);
@@ -127,12 +131,22 @@ test.describe('toggleMilestoneComplete', () => {
     await addMilestone(page, 'Test Milestone');
 
     const milestoneCheckbox = page.getByTestId('milestone-checkbox');
-    await milestoneCheckbox.click();
-    await page.waitForTimeout(300);
 
-    // Uncheck milestone
+    // Check the milestone
+    const firstCheckResponse = page.waitForResponse(
+      (resp) => resp.url().includes('/milestones') && resp.request().method() === 'PATCH',
+      { timeout: 5000 }
+    );
     await milestoneCheckbox.click();
-    await page.waitForTimeout(300);
+    await firstCheckResponse;
+
+    // Uncheck the milestone
+    const secondCheckResponse = page.waitForResponse(
+      (resp) => resp.url().includes('/milestones') && resp.request().method() === 'PATCH',
+      { timeout: 5000 }
+    );
+    await milestoneCheckbox.click();
+    await secondCheckResponse;
 
     const milestoneData = await getMilestoneForGoal(page, firstGoalId, 'completed, completed_at');
     expect(milestoneData?.completed).toBe(false);
@@ -146,13 +160,17 @@ test.describe('deleteMilestone', () => {
     await expandGoalModal(page);
     await addMilestone(page, 'Test Milestone');
 
-    // Expand milestone by clicking the row
+    // Expand milestone by clicking the row and wait for the delete button to appear
     await page.getByTestId('milestone-item').click();
-    await page.waitForTimeout(200);
+    await page.waitForSelector('button:has-text("Delete")', { timeout: 3000 });
 
-    // Click delete button
+    // Click delete button and wait for the DELETE request to confirm removal
+    const deleteResponse = page.waitForResponse(
+      (resp) => resp.url().includes('/milestones') && resp.request().method() === 'DELETE',
+      { timeout: 5000 }
+    );
     await page.click('button:has-text("Delete")');
-    await page.waitForTimeout(300);
+    await deleteResponse;
 
     // Verify milestone is gone from UI
     const milestoneCount = await page.locator('text=Test Milestone').count();
@@ -280,7 +298,7 @@ test.describe('Milestone ordering', () => {
         }, 50);
       });
     });
-    await page.waitForTimeout(1000);
+    await page.waitForSelector('[data-testid="milestone-item"]', { timeout: 3000 });
 
     const milestoneData = await getMilestonesForGoal(page, firstGoalId, 'title, position');
     expect(milestoneData![0].title).toBe('Second');
@@ -316,7 +334,7 @@ test.describe('Milestone ordering', () => {
       steps: 20
     });
     await page.mouse.up();
-    await page.waitForTimeout(1000);
+    await page.waitForSelector('[data-testid="milestone-item"]', { timeout: 3000 });
 
     const milestoneData = await getMilestonesForGoal(page, firstGoalId, 'title, position');
     expect(milestoneData).toHaveLength(3);
@@ -362,7 +380,7 @@ test.describe('Milestone ordering', () => {
       steps: 10
     });
     await page.mouse.up();
-    await page.waitForTimeout(500);
+    await page.waitForSelector('[data-testid="milestone-item"]', { timeout: 3000 });
 
     const updatedData = await getGoalData<{ last_updated_at: string }>(
       page,
@@ -381,7 +399,8 @@ test.describe('Milestone ordering', () => {
 
     // Expand first milestone (click on the milestone row, not checkbox or handle)
     await page.getByTestId('milestone-item').nth(0).click();
-    await page.waitForTimeout(200);
+    // Wait for the title input to confirm expansion
+    await page.waitForSelector('input[placeholder="Milestone title..."]', { timeout: 3000 });
 
     // Verify expanded (should have input field visible)
     const titleInput = await page.locator('input[placeholder="Milestone title..."]').count();
@@ -405,7 +424,7 @@ test.describe('Milestone ordering', () => {
       steps: 20
     });
     await page.mouse.up();
-    await page.waitForTimeout(1000);
+    await page.waitForSelector('[data-testid="milestone-item"]', { timeout: 3000 });
 
     // Verify milestone is still expanded
     const titleInputAfter = await page.locator('input[placeholder="Milestone title..."]').count();
@@ -438,7 +457,7 @@ test.describe('Milestone ordering', () => {
     await page.mouse.down();
     await page.mouse.move(firstBox.x + firstBox.width / 2 + 5, firstBox.y + firstBox.height / 2);
     await page.mouse.up();
-    await page.waitForTimeout(500);
+    await page.waitForSelector('[data-testid="milestone-item"]', { timeout: 3000 });
 
     const finalData = await getMilestonesForGoal(page, firstGoalId, 'title, position');
     expect(finalData).toEqual(initialData);

--- a/tests/test-helpers.ts
+++ b/tests/test-helpers.ts
@@ -123,17 +123,23 @@ export async function closeModal(page: Page): Promise<void> {
 }
 
 /**
- * Wait for auto-save to complete (default 600ms debounce)
+ * Wait for auto-save to complete by watching for the debounced PATCH request to /goals
  */
 export async function waitForAutoSave(page: Page): Promise<void> {
-  await page.waitForTimeout(600);
+  await page.waitForResponse(
+    (resp) => resp.url().includes('/goals') && resp.request().method() === 'PATCH',
+    { timeout: 5000 }
+  );
 }
 
 /**
- * Wait for checkbox update to complete
+ * Wait for checkbox update to complete by watching for the PATCH request to /goals
  */
 export async function waitForCheckboxUpdate(page: Page): Promise<void> {
-  await page.waitForTimeout(300);
+  await page.waitForResponse(
+    (resp) => resp.url().includes('/goals') && resp.request().method() === 'PATCH',
+    { timeout: 5000 }
+  );
 }
 
 /**
@@ -142,8 +148,12 @@ export async function waitForCheckboxUpdate(page: Page): Promise<void> {
 export async function addMilestone(page: Page, title: string): Promise<void> {
   await page.click('text=+ Add');
   await page.fill('input[placeholder="New milestone..."]', title);
+  const saveRequest = page.waitForResponse(
+    (resp) => resp.url().includes('/milestones') && resp.request().method() === 'POST',
+    { timeout: 5000 }
+  );
   await page.click('button.bg-blue-500:has-text("Add")');
-  await page.waitForTimeout(300);
+  await saveRequest;
 }
 
 /**


### PR DESCRIPTION
## Summary

Replaces all `waitForTimeout` fixed sleeps in the Playwright test suite with proper event-driven waits. This makes tests faster, more deterministic, and fail immediately on regressions rather than sleeping before failing.

## Changes

- `tests/test-helpers.ts` — replaced `waitForAutoSave`, `waitForCheckboxUpdate`, `addMilestone` sleeps
- `tests/goals.spec.ts` — replaced inline `waitForTimeout` calls
- `tests/milestones.spec.ts` — replaced inline `waitForTimeout` calls

## Testing

All `waitForTimeout` calls removed. Replaced with `waitForResponse` for network events and `waitForSelector`/`locator.waitFor()` for DOM state changes.

Fixes xsaardo/bingo#79