### PR TITLE
feat: wire up ConversionPrompt for share attempt and second board creation (issue #82)

### DIFF
--- a/src/routes/boards/[id]/+page.svelte
+++ b/src/routes/boards/[id]/+page.svelte
@@ -15,8 +15,10 @@
     currentBoardError
   } from '$lib/stores/currentBoard';
   import { isAnonymous } from '$lib/stores/auth';
+  import ConversionPrompt from '$lib/components/ConversionPrompt.svelte';
 
   let exportElement: HTMLDivElement | undefined = $state();
+  let showShareConversionPrompt = $state(false);
 
   const boardId = $derived($page.params.id!);
 
@@ -37,6 +39,10 @@
 
   async function handleShare() {
     if (!$currentBoard) return;
+    if ($isAnonymous) {
+      showShareConversionPrompt = true;
+      return;
+    }
     if ($currentBoard.isPublic) {
       await currentBoardStore.setPublic(boardId, false);
       toast('Sharing disabled');
@@ -45,6 +51,10 @@
       await navigator.clipboard.writeText(shareUrl);
       toast.success('Link copied to clipboard');
     }
+  }
+
+  function handleShareConversionDismiss() {
+    showShareConversionPrompt = false;
   }
 </script>
 
@@ -231,4 +241,11 @@
   {#if $currentBoard}
     <ExportableBoard board={$currentBoard} bind:exportRef={exportElement} />
   {/if}
+
+  <!-- Conversion Prompt for anonymous share attempt -->
+  <ConversionPrompt
+    trigger="share"
+    isOpen={showShareConversionPrompt}
+    onDismiss={handleShareConversionDismiss}
+  />
 </AuthGuard>

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -8,9 +8,12 @@
   import DeleteBoardModal from '$lib/components/DeleteBoardModal.svelte';
   import ErrorAlert from '$lib/components/ErrorAlert.svelte';
   import { boardsStore, boards, boardsLoading, boardsError, hasBoards } from '$lib/stores/boards';
+  import { isAnonymous } from '$lib/stores/auth';
+  import ConversionPrompt from '$lib/components/ConversionPrompt.svelte';
   import type { Board } from '$lib/types';
 
   let showCreateModal = $state(false);
+  let showCreateConversionPrompt = $state(false);
   let showDeleteModal = $state(false);
   let boardToDelete: Board | null = $state(null);
 
@@ -20,7 +23,15 @@
   });
 
   function handleCreateBoard() {
+    if ($isAnonymous && $boards.length >= 1) {
+      showCreateConversionPrompt = true;
+      return;
+    }
     showCreateModal = true;
+  }
+
+  function handleCreateConversionDismiss() {
+    showCreateConversionPrompt = false;
   }
 
   function handleCloseCreateModal() {
@@ -238,5 +249,12 @@
     board={boardToDelete}
     onClose={handleCloseDeleteModal}
     onDeleted={handleBoardDeleted}
+  />
+
+  <!-- Conversion Prompt for anonymous second board creation -->
+  <ConversionPrompt
+    trigger="share"
+    isOpen={showCreateConversionPrompt}
+    onDismiss={handleCreateConversionDismiss}
   />
 </AuthGuard>


### PR DESCRIPTION
## Summary

Wires up the two missing conversion moments for anonymous users:

1. **Share button** — anonymous users now see `ConversionPrompt` with `trigger="share"` instead of immediately making the board public
2. **Second board creation** — anonymous users with an existing board now see `ConversionPrompt` before the create modal opens

## Changes

- `src/routes/boards/[id]/+page.svelte` — intercept `handleShare()` for anon users
- `src/routes/dashboard/+page.svelte` — intercept `handleCreateBoard()` for anon users with ≥1 board

## Testing

Followed existing `ConversionPrompt` usage pattern from `MilestoneList.svelte`.

Fixes xsaardo/bingo#82