### PR TITLE
fix: modal checkbox not updating visually when clicked

### DIFF
--- a/src/lib/components/CheckboxButton.svelte
+++ b/src/lib/components/CheckboxButton.svelte
@@ -1,5 +1,5 @@
 <!-- ABOUTME: Thin wrapper around shadcn-svelte Checkbox for milestone and goal completion -->
-<!-- ABOUTME: Maintains backward-compatible onclick/testid API over the bits-ui Checkbox primitive -->
+<!-- ABOUTME: Uses bind:checked with local state so bits-ui can manage visual state correctly -->
 
 <script lang="ts">
   import { Checkbox } from '$lib/components/ui/checkbox/index.js';
@@ -12,6 +12,13 @@
   }
 
   let { checked, onclick, testid = 'checkbox', class: className = 'w-5 h-5' }: Props = $props();
+
+  let internalChecked = $state(checked);
+
+  // Sync internal state when the external checked prop changes (e.g. store updates)
+  $effect(() => {
+    internalChecked = checked;
+  });
 </script>
 
-<Checkbox {checked} onCheckedChange={() => {}} {onclick} data-testid={testid} class={className} />
+<Checkbox bind:checked={internalChecked} {onclick} data-testid={testid} class={className} />

--- a/tests/goals.spec.ts
+++ b/tests/goals.spec.ts
@@ -112,6 +112,17 @@ test.describe('Goal modal', () => {
 });
 
 test.describe('Goal completion', () => {
+  test('clicking modal checkbox immediately updates its visual state', async ({ page }) => {
+    await openFirstGoalModal(page);
+
+    const checkbox = page.getByTestId('modal-checkbox');
+    await expect(checkbox).not.toBeChecked();
+
+    await checkbox.click();
+
+    await expect(checkbox).toBeChecked();
+  });
+
   test('toggling goal completion updates the checkbox state', async ({ page }) => {
     await openFirstGoalModal(page);
 


### PR DESCRIPTION
bits-ui v2 requires bind:checked (two-way binding) to reflect external state changes. Passing checked={...} one-way with a no-op onCheckedChange meant bits-ui could not sync its visual state, causing the modal checkbox to stay unchecked after clicking even though the store updated correctly.

Fix CheckboxButton to use a local $state with bind:checked so bits-ui manages the visual state properly, with a $effect to sync when the external checked prop changes.