### PR TITLE
fix: decouple board grid sizing from card dimensions

### DIFF
--- a/src/lib/components/BingoBoard.svelte
+++ b/src/lib/components/BingoBoard.svelte
@@ -67,7 +67,10 @@
   <BoardLayout
     name={$currentBoard.name}
     size={$currentBoard.size}
-    gridClass="grid gap-2 sm:gap-3 flex-1 min-h-0 aspect-square self-center"
+    gridClass="grid gap-2 sm:gap-3"
+    gridStyle="height: 100cqi"
+    gridWrapperClass="w-full"
+    gridWrapperStyle="container-type: inline-size"
   >
     {#snippet cell(index)}
       <GoalSquare

--- a/src/lib/components/BoardLayout.svelte
+++ b/src/lib/components/BoardLayout.svelte
@@ -14,6 +14,9 @@
     titleStyle?: string;
     gridClass?: string;
     gridStyle?: string;
+    // When provided, wraps the grid in a sizing container so fr rows get a definite height
+    gridWrapperClass?: string;
+    gridWrapperStyle?: string;
     cell: Snippet<[index: number]>;
     footer?: Snippet;
   }
@@ -22,12 +25,14 @@
     name,
     size,
     cellSize,
-    cardClass = 'bg-white rounded-lg shadow-lg p-2 sm:p-3 md:p-4 relative h-full flex flex-col',
+    cardClass = 'bg-white rounded-lg shadow-lg p-2 sm:p-3 md:p-4 relative flex flex-col',
     cardStyle,
     titleClass = 'font-bold text-gray-900 text-center shrink-0 pb-2 sm:pb-3 truncate',
     titleStyle = 'font-size: 1.8em',
     gridClass = 'flex-1 min-h-0',
     gridStyle,
+    gridWrapperClass,
+    gridWrapperStyle,
     cell,
     footer
   }: Props = $props();
@@ -40,13 +45,23 @@
   );
 </script>
 
-<div class={cardClass} style={cardStyle}>
-  <h1 class={titleClass} style={titleStyle}>{name}</h1>
+{#snippet gridElement()}
   <div class={gridClass} style={computedGridStyle}>
     {#each { length: size * size } as _, index}
       {@render cell(index)}
     {/each}
   </div>
+{/snippet}
+
+<div class={cardClass} style={cardStyle}>
+  <h1 class={titleClass} style={titleStyle}>{name}</h1>
+  {#if gridWrapperClass || gridWrapperStyle}
+    <div class={gridWrapperClass} style={gridWrapperStyle}>
+      {@render gridElement()}
+    </div>
+  {:else}
+    {@render gridElement()}
+  {/if}
 </div>
 {#if footer}
   {@render footer()}

--- a/src/routes/boards/[id]/+page.svelte
+++ b/src/routes/boards/[id]/+page.svelte
@@ -257,7 +257,7 @@
         >
           <div
             class:font-chanellie={$currentBoard.font === 'chanellie'}
-            style="width: min(100cqh - 2rem, 100cqw, 56rem); height: min(100cqh - 2rem, 100cqw, 56rem);"
+            style="width: min(100cqh - 8rem, 100cqw, 56rem);"
           >
             <BingoBoard />
           </div>

--- a/src/routes/share/[id]/+page.svelte
+++ b/src/routes/share/[id]/+page.svelte
@@ -86,7 +86,7 @@
         class="flex-1 min-h-0 w-full flex items-center justify-center"
         style="container-type: size;"
       >
-        <div style="width: min(100cqh, 100cqw, 56rem); height: min(100cqh, 100cqw, 56rem);">
+        <div style="width: min(100cqh - 8rem, 100cqw, 56rem);">
           <BingoBoard readonly={true} />
         </div>
       </div>


### PR DESCRIPTION
Make the grid area square independently of the overall card shape. Previously the card was forced square, making cells wider than tall due to the title consuming vertical space. Now the grid uses container-type: inline-size + height: 100cqi so fr rows get a definite height equal to the wrapper width, producing square cells. The card becomes rectangular (title + square grid).