### PR TITLE
fix: hide orphaned separator in prod user menu; align sharing popover style

### DIFF
--- a/src/lib/components/UserMenu.svelte
+++ b/src/lib/components/UserMenu.svelte
@@ -94,9 +94,8 @@
               Test Auth (Debug)
             </a>
           </DropdownMenu.Item>
+          <DropdownMenu.Separator />
         {/if}
-
-        <DropdownMenu.Separator />
 
         <!-- Logout -->
         <DropdownMenu.Item

--- a/src/routes/boards/[id]/+page.svelte
+++ b/src/routes/boards/[id]/+page.svelte
@@ -114,7 +114,10 @@
                       </Button>
                     {/snippet}
                   </Popover.Trigger>
-                  <Popover.Content class="w-80 bg-white" align="end">
+                  <Popover.Content
+                    class="w-80 rounded-lg border-gray-200 bg-white shadow-lg"
+                    align="end"
+                  >
                     <p class="text-sm font-medium mb-2">Share link</p>
                     <div class="flex gap-2">
                       <Input


### PR DESCRIPTION
## Summary

Fixes two UI inconsistencies reported in issue #137:

1. **Orphaned separator in production user menu** — The `<DropdownMenu.Separator />` was always rendered even when the "Test Auth (Debug)" menu item above it was hidden (dev-only). In production this left a floating divider with nothing above it.

2. **Sharing popover visual inconsistency** — The share link popover used default popover styles (`rounded-md`, `shadow-md`, plain `border`) while the user menu dropdown used `rounded-lg border-gray-200 bg-white shadow-lg`. The popover now matches.

## Changes

- `src/lib/components/UserMenu.svelte`: moved `<DropdownMenu.Separator />` inside the `{#if import.meta.env.DEV}` block so it is only rendered alongside the debug item
- `src/routes/boards/[id]/+page.svelte`: updated sharing `<Popover.Content>` class from `w-80 bg-white` to `w-80 rounded-lg border-gray-200 bg-white shadow-lg` to match dropdown style

## Testing

- `npm run check` — same pre-existing env-var warnings as on `main`, no new errors
- `npm run test:unit` — all 26 tests pass

Fixes xsaardo/bingo#137