### PR TITLE
fix: bingo board positioned too far down viewport on mobile

### DIFF
--- a/src/routes/boards/[id]/+page.svelte
+++ b/src/routes/boards/[id]/+page.svelte
@@ -252,7 +252,7 @@
       {:else if $currentBoard}
         <!-- BingoBoard Component -->
         <div
-          class="flex-1 min-h-0 w-full flex items-center justify-center"
+          class="flex-1 min-h-0 w-full flex items-start sm:items-center justify-center"
           style="container-type: size;"
         >
           <div

--- a/src/routes/share/[id]/+page.svelte
+++ b/src/routes/share/[id]/+page.svelte
@@ -83,7 +83,7 @@
       </div>
     {:else if $currentBoard}
       <div
-        class="flex-1 min-h-0 w-full flex items-center justify-center"
+        class="flex-1 min-h-0 w-full flex items-start sm:items-center justify-center"
         style="container-type: size;"
       >
         <div style="width: min(100cqh - 8rem, 100cqw, 56rem);">


### PR DESCRIPTION
## Summary

On mobile, the bingo board was vertically centered in the remaining viewport height, causing a large visible gap of background image between the header and the board card.

## Root Cause

Both board pages (`/boards/[id]` and `/share/[id]`) used `items-center justify-center` on the board container, which centers the board both horizontally **and** vertically in the available space below the header. On mobile viewports this pushes the board to the visual midpoint of the screen, making it appear far below the fold.

## Changes

- `src/routes/boards/[id]/+page.svelte`: changed `items-center` → `items-start sm:items-center`
- `src/routes/share/[id]/+page.svelte`: changed `items-center` → `items-start sm:items-center`

This aligns the board to the top of the content area on mobile while preserving the centered layout on larger screens.

## Testing

- Verified the Tailwind classes render correctly at mobile (`< 640px`) and desktop breakpoints
- No existing tests broken (unit tests pass)

Fixes xsaardo/bingo#144