### PR TITLE
fix: remove gradient from Create Board modal header

### DIFF
--- a/src/lib/components/CreateBoardModal.svelte
+++ b/src/lib/components/CreateBoardModal.svelte
@@ -66,11 +66,11 @@
     class="bg-white rounded-2xl shadow-2xl max-w-md w-full overflow-hidden p-0 border-0 gap-0"
   >
     <!-- Header -->
-    <div class="bg-gradient-to-r from-blue-600 to-purple-600 px-6 py-5">
+    <div class="px-6 py-5 border-b border-gray-200">
       <div class="flex items-center justify-between">
-        <Dialog.Title class="text-xl font-bold text-white">Create New Board</Dialog.Title>
+        <Dialog.Title class="text-xl font-bold text-gray-900">Create New Board</Dialog.Title>
         <Dialog.Close
-          class="text-white hover:bg-white hover:bg-opacity-20 rounded-lg p-1 transition-colors"
+          class="text-gray-400 hover:text-gray-600 rounded-lg p-1 transition-colors"
           aria-label="Close modal"
         >
           <svg class="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">


### PR DESCRIPTION
## Summary

The Create Board modal header had a `bg-gradient-to-r from-blue-600 to-purple-600` Tailwind gradient that clashed with the clean, minimal white aesthetic used throughout the rest of the app. This PR removes the gradient and replaces it with a plain white header and a subtle bottom border, consistent with how other modals (GoalModal, ConfirmationModal) are styled.

## Changes

- `src/lib/components/CreateBoardModal.svelte`
  - Replaced `bg-gradient-to-r from-blue-600 to-purple-600` header background with `border-b border-gray-200` (plain white with subtle divider)
  - Updated `Dialog.Title` text color from `text-white` to `text-gray-900`
  - Updated close button from white-on-gradient styling (`text-white hover:bg-white hover:bg-opacity-20`) to neutral styling (`text-gray-400 hover:text-gray-600`)

## Testing

- Prettier confirmed no formatting changes needed
- Unit test runner not installed in deps but the change is purely cosmetic CSS class updates with no logic changes

Fixes xsaardo/bingo#141