### PR TITLE
fix: restore left border and rounded corner on milestone input

### DIFF
--- a/src/lib/components/MilestoneList.svelte
+++ b/src/lib/components/MilestoneList.svelte
@@ -118,7 +118,7 @@
       <Input
         bind:value={newMilestoneTitle}
         placeholder="New milestone..."
-        class="flex-1 px-3 py-2 h-auto text-sm"
+        class="flex-1 px-3 py-2 h-auto text-sm min-w-0"
         onkeydown={(e) => e.key === 'Enter' && handleAdd()}
       />
       <button


### PR DESCRIPTION
## Summary

Fixes #139

## Root Cause

The "New milestone..." input in `MilestoneList.svelte` is rendered inside an `overflow-hidden` container (used for the grid expand/collapse animation in `GoalModal`). The input's left edge was **flush against** the `overflow-hidden` clip boundary.

The base `<Input>` component includes `w-full` (sets `width: 100%`) in its default classes. When combined with `flex-1` in a flex row that also contains Add/Cancel buttons, this creates a **sub-pixel overflow**: the input renders slightly wider than its flex-allocated space, and the leftmost pixels overflow beyond the clip boundary. The `overflow: hidden` ancestor clips those pixels, making the left border and rounded corner **appear missing**.

## Fix

Added `min-w-0` to the input's class in `MilestoneList.svelte`:

```diff
- class="flex-1 px-3 py-2 h-auto text-sm"
+ class="flex-1 px-3 py-2 h-auto text-sm min-w-0"
```

`min-w-0` sets `min-width: 0` on the flex item, allowing it to shrink to exactly its flex-allocated size with no sub-pixel overflow. The left border and rounded corner are no longer clipped.

## Verified

Tested visually in Chrome with a reproduction page confirming the left border is restored with `min-w-0`. All 26 unit tests pass.