### PR TITLE
fix: replace '+ Add' milestone button with shadcn Button component

### DIFF
--- a/src/lib/components/MilestoneList.svelte
+++ b/src/lib/components/MilestoneList.svelte
@@ -2,6 +2,7 @@
   import type { Milestone } from '$lib/types';
   import MilestoneItem from './MilestoneItem.svelte';
   import { Input } from '$lib/components/ui/input/index.js';
+  import { Button } from '$lib/components/ui/button/index.js';
   import { currentBoardStore } from '$lib/stores/currentBoard';
   import { currentUser } from '$lib/stores/auth';
   import { dndzone } from 'svelte-dnd-action';
@@ -105,12 +106,14 @@
       <span>✓</span>
       Milestones ({completedCount}/{totalCount} complete)
     </h3>
-    <button
+    <Button
+      variant="link"
+      size="sm"
       onclick={handleAddClick}
-      class="text-sm text-blue-600 hover:text-blue-700 font-medium transition-colors"
+      class="h-auto p-0 text-sm font-medium"
     >
       + Add
-    </button>
+    </Button>
   </div>
 
   {#if showAddInput}


### PR DESCRIPTION
## Root Cause

The `+ Add` button in `MilestoneList.svelte` was a raw `<button>` HTML element styled with Tailwind classes (`text-blue-600 hover:text-blue-700`). It lacked proper hover feedback (no underline) and was inconsistent with the shadcn-svelte component system used throughout the app.

## Fix

- Imported `Button` from `$lib/components/ui/button/index.js`
- Replaced the raw `<button>` with `<Button variant="link" size="sm">`
- The `link` variant provides `underline-offset-4 hover:underline` hover feedback on hover as requested
- Added `class="h-auto p-0 text-sm font-medium"` to preserve the original compact sizing and spacing
- Click handler (`onclick={handleAddClick}`) and all functionality remain unchanged

## Testing

All 26 unit tests pass (`npm run test:unit`).

Fixes xsaardo/bingo#140