### PR TITLE
fix: always show board rename button on touch/mobile devices

### DIFF
--- a/src/lib/components/BoardCard.svelte
+++ b/src/lib/components/BoardCard.svelte
@@ -162,7 +162,7 @@
             </h3>
             <button
               onclick={handleEditClick}
-              class="flex-shrink-0 p-1 text-gray-300 hover:text-blue-500 rounded opacity-0 group-hover/name:opacity-100 transition-all"
+              class="flex-shrink-0 p-1 text-gray-300 hover:text-blue-500 rounded opacity-100 sm:opacity-0 sm:group-hover/name:opacity-100 transition-all"
               title="Rename board"
               type="button"
             >


### PR DESCRIPTION
## Summary

Fixes #145

## Root Cause

The board rename/edit button in `BoardCard.svelte` used the Tailwind classes `opacity-0 group-hover/name:opacity-100`, which hides the button by default and only reveals it on mouse hover. On touch/mobile devices, there is no hover state, making the button permanently invisible and the rename feature completely inaccessible.

## Fix

Changed the button classes from:
```
opacity-0 group-hover/name:opacity-100
```
to:
```
opacity-100 sm:opacity-0 sm:group-hover/name:opacity-100
```

This makes the edit button:
- **Always visible** on mobile screens (below `sm` breakpoint, i.e. < 640px)
- **Hover-reveal only** on desktop screens (sm+), preserving the existing clean desktop UX

## Files Changed
- `src/lib/components/BoardCard.svelte` — one-line Tailwind class change on the rename button