### PR TITLE
fix: standardize border radius across modals and buttons

### DIFF
--- a/src/lib/components/BoardCard.svelte
+++ b/src/lib/components/BoardCard.svelte
@@ -132,7 +132,7 @@
               />
               <button
                 onclick={cancelEdit}
-                class="flex-shrink-0 p-1 text-gray-400 hover:text-gray-600 rounded transition-colors"
+                class="flex-shrink-0 p-1 text-gray-400 hover:text-gray-600 rounded-lg transition-colors"
                 title="Cancel"
                 type="button"
               >
@@ -162,7 +162,7 @@
             </h3>
             <button
               onclick={handleEditClick}
-              class="flex-shrink-0 p-1 text-gray-300 hover:text-blue-500 rounded opacity-100 sm:opacity-0 sm:group-hover/name:opacity-100 transition-all"
+              class="flex-shrink-0 p-1 text-gray-300 hover:text-blue-500 rounded-lg opacity-100 sm:opacity-0 sm:group-hover/name:opacity-100 transition-all"
               title="Rename board"
               type="button"
             >

--- a/src/lib/components/GoalModal.svelte
+++ b/src/lib/components/GoalModal.svelte
@@ -58,7 +58,7 @@
 
 <Dialog.Root open={true} onOpenChange={handleOpenChange}>
   <Dialog.Content
-    class="bg-white rounded-lg shadow-2xl max-w-2xl w-full max-h-[90vh] flex flex-col overflow-hidden p-0 border-0 gap-0"
+    class="bg-white rounded-2xl shadow-2xl max-w-2xl w-full max-h-[90vh] flex flex-col overflow-hidden p-0 border-0 gap-0"
     data-testid="goal-modal"
   >
     <!-- Header -->


### PR DESCRIPTION
## Summary

Standardizes border radius values across modals and buttons to eliminate visual inconsistencies.

### Changes

**`src/lib/components/GoalModal.svelte`**
- Main modal container: `rounded-lg` → `rounded-2xl` to match all other modals (CreateBoardModal, DeleteBoardModal, ConfirmationModal)

**`src/lib/components/BoardCard.svelte`**
- Cancel edit button: `rounded` → `rounded-lg` to match app-wide button style
- Rename board icon button: `rounded` → `rounded-lg` to match app-wide button style

> Note: The edit input field (`rounded`) and progress bar elements (`rounded-full`) were intentionally left unchanged — only button elements were updated.

Fixes xsaardo/bingo#152