### PR TITLE
fix: add <main> landmark element to pages missing it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3483,9 +3483,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -65,17 +65,17 @@
 
 {#if !$isAuthInitialized}
   <!-- Loading state -->
-  <div class="min-h-screen flex items-center justify-center">
+  <main class="min-h-screen flex items-center justify-center">
     <div class="text-center">
       <div
         class="animate-spin rounded-full h-12 w-12 border-b-4 border-blue-600 mx-auto mb-4"
       ></div>
       <p class="text-gray-600">Loading...</p>
     </div>
-  </div>
+  </main>
 {:else if $authError}
   <!-- Auth init failed -->
-  <div class="min-h-screen flex items-center justify-center">
+  <main class="min-h-screen flex items-center justify-center">
     <div class="text-center">
       <p data-testid="auth-error-message" class="text-red-600 mb-4">{$authError}</p>
       <button
@@ -86,7 +86,7 @@
         Try again
       </button>
     </div>
-  </div>
+  </main>
 {:else}
   <!-- Landing page with inline board creation -->
   <div class="min-h-screen flex flex-col">
@@ -113,7 +113,7 @@
       </div>
     </header>
 
-    <div class="flex-1 flex items-center justify-center p-4">
+    <main class="flex-1 flex items-center justify-center p-4">
       <div class="max-w-2xl w-full">
         <div
           class="text-center mb-8 inline-block bg-white/70 backdrop-blur-sm rounded-2xl px-5 py-3 w-full"
@@ -260,7 +260,7 @@
           </div>
         </div>
       </div>
-    </div>
+    </main>
     <footer class="py-6 text-center text-sm text-gray-400 bg-white/70 backdrop-blur-sm">
       <p>
         © {new Date().getFullYear()} Bingoals &middot;

--- a/src/routes/auth/callback/+page.svelte
+++ b/src/routes/auth/callback/+page.svelte
@@ -33,7 +33,7 @@
   });
 </script>
 
-<div class="min-h-screen flex items-center justify-center p-4">
+<main class="min-h-screen flex items-center justify-center p-4">
   <div class="max-w-md w-full bg-white rounded-lg shadow-lg p-8 text-center">
     {#if status === 'loading'}
       <div class="space-y-4">
@@ -79,4 +79,4 @@
       </div>
     {/if}
   </div>
-</div>
+</main>

--- a/src/routes/auth/login/+page.svelte
+++ b/src/routes/auth/login/+page.svelte
@@ -22,7 +22,7 @@
   <title>Sign In - Bingoals</title>
 </svelte:head>
 
-<div class="min-h-screen flex items-center justify-center p-4">
+<main class="min-h-screen flex items-center justify-center p-4">
   <div class="w-full max-w-md">
     <!-- Header -->
     <div class="text-center mb-8">
@@ -54,4 +54,4 @@
       </div>
     {/if}
   </div>
-</div>
+</main>

--- a/src/routes/auth/logout/+page.svelte
+++ b/src/routes/auth/logout/+page.svelte
@@ -30,7 +30,7 @@
   <title>Signing Out - Bingo Board</title>
 </svelte:head>
 
-<div class="min-h-screen flex items-center justify-center p-4">
+<main class="min-h-screen flex items-center justify-center p-4">
   <div class="max-w-md w-full bg-white rounded-lg shadow-lg p-8 text-center">
     {#if status === 'loading'}
       <div class="space-y-4">
@@ -76,4 +76,4 @@
       </div>
     {/if}
   </div>
-</div>
+</main>


### PR DESCRIPTION
## Summary

Adds `<main>` landmark elements to the four pages that were missing them, improving accessibility for screen reader users.

## Files changed

| File | Change |
|------|--------|
| `src/routes/+page.svelte` | Replaced outermost content `<div>` (below `<header>`) with `<main>`; loading and auth-error states also wrapped in `<main>` |
| `src/routes/auth/login/+page.svelte` | Replaced outermost `<div class="min-h-screen ...">` with `<main>` |
| `src/routes/auth/callback/+page.svelte` | Replaced outermost `<div class="min-h-screen ...">` with `<main>` |
| `src/routes/auth/logout/+page.svelte` | Replaced outermost `<div class="min-h-screen ...">` with `<main>` |

All existing classes are preserved. Each page now has exactly one `<main>` landmark in the DOM at any given time (the landing page has three `<main>` elements in separate `{#if}`/`{:else if}`/`{:else}` branches — only one renders per state).

Fixes xsaardo/bingo#160
