### PR TITLE
feat: add global teardown to clean up test user boards after each CI run

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3483,9 +3483,9 @@
       }
     },
     "node_modules/flatted": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.1.tgz",
-      "integrity": "sha512-IxfVbRFVlV8V/yRaGzk0UVIcsKKHMSfYw66T/u4nTwlWteQePsxe//LjudR1AMX4tZW3WFCh3Zqa/sjlqpbURQ==",
+      "version": "3.4.2",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-3.4.2.tgz",
+      "integrity": "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==",
       "dev": true,
       "license": "ISC"
     },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -16,6 +16,7 @@ dotenv.config({ path: resolve(__dirname, '.env.test') });
  */
 export default defineConfig({
   testDir: './tests',
+  globalTeardown: './tests/global-teardown.ts',
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/tests/global-teardown.ts
+++ b/tests/global-teardown.ts
@@ -1,0 +1,35 @@
+// ABOUTME: Playwright global teardown — runs once after all tests complete.
+// ABOUTME: Deletes all boards owned by the test user to prevent accumulation across CI runs.
+import { createClient } from '@supabase/supabase-js';
+
+export default async function globalTeardown() {
+  const url = process.env.PUBLIC_SUPABASE_URL;
+  const key = process.env.PUBLIC_SUPABASE_ANON_KEY;
+  const email = process.env.TEST_USER_EMAIL || 'test@example.com';
+  const password = process.env.TEST_USER_PASSWORD || 'test-password-123';
+
+  if (!url || !key) {
+    console.warn('[teardown] Missing Supabase env vars — skipping board cleanup.');
+    return;
+  }
+
+  const supabase = createClient(url, key);
+
+  const { error: signInError } = await supabase.auth.signInWithPassword({ email, password });
+  if (signInError) {
+    console.warn('[teardown] Sign in failed — skipping board cleanup:', signInError.message);
+    return;
+  }
+
+  const {
+    data: { user }
+  } = await supabase.auth.getUser();
+  if (!user) return;
+
+  const { error } = await supabase.from('boards').delete().eq('user_id', user.id);
+  if (error) {
+    console.warn('[teardown] Board cleanup failed:', error.message);
+  } else {
+    console.log(`[teardown] Cleaned up boards for ${user.email}`);
+  }
+}


### PR DESCRIPTION
Accumulated boards from failed/interrupted tests were slowing fetchBoards enough to cause flaky heading-not-found failures in goals, milestones, and rich-text-editor tests. The teardown runs after every suite completion.