### PR TITLE
feat: whimsical minimalist journaling aesthetic redesign

### DIFF
--- a/.agent-task.md
+++ b/.agent-task.md
@@ -1,0 +1,60 @@
+# Task: Address PR #173 review comments on fix/issue-169 branch
+
+You are on the `fix/issue-169` branch. This PR redesigns the UI with a whimsical minimalist journaling aesthetic (pale lavender-gray + royal blue-indigo + dot-grid texture + pill buttons).
+
+## Review feedback to fix
+
+### Bug 1: Dark mode regression — hardcoded body background-color (src/app.css)
+
+The body has:
+body { background-color: oklch(0.932 0.01 267); background-image: radial-gradient(...); }
+
+This hardcodes the light color and will NOT respond to the .dark class. Fix:
+body { background-color: var(--background); background-image: radial-gradient(...); }
+
+Also add a dark mode override:
+.dark body {
+background-color: var(--background);
+background-image: none; /_ remove dot-grid in dark mode — dots are light-hued and will glare _/
+}
+
+### Bug 2: Dot-grid radial-gradient dark mode
+
+The dot color in the radial-gradient is a light hue (oklch ~0.82) — fine on light bg, but glaring on dark. Covered by the `.dark body { background-image: none; }` fix above (removes the texture in dark mode). Alternatively, use a dark-appropriate dot color if you want to preserve the texture — something like oklch(0.3 0.01 267) for subtle dark dots.
+
+### Inconsistency: button.svelte sm/lg still have rounded-md (src/lib/components/ui/button/button.svelte)
+
+The base button class was changed to `rounded-full` for pill shape. But the size variants `sm` and `lg` still include `rounded-md` in their classes. Since tailwind-merge resolves in favor of the size variant, sm/lg are still rounded-md not pill-shaped.
+
+Fix: Remove `rounded-md` from the `sm` and `lg` size variant classes. Do NOT add rounded-full there — it's already set in the base and will cascade correctly once rounded-md is removed.
+
+### Minor: Two sources of truth for background color (src/app.css)
+
+There's both:
+body { background-color: oklch(0.932 0.01 267) }
+:root { --background: oklch(0.932 0.01 267) }
+
+After fixing Bug 1 (using var(--background) on body), this is already resolved. Just make sure only one place defines the color value — the :root token.
+
+## Additional scope (from owner comment)
+
+"Feel free to modify the rest of the elements, such as the board cards and bingo board itself to fit this aesthetic."
+
+Extend the whimsical minimalist journaling look to:
+
+- Board cards on the dashboard (`src/routes/dashboard/+page.svelte`) — apply lavender-gray tones, royal blue-indigo accents, flat/no-shadow card styling, pill buttons
+- Bingo board view (`src/routes/boards/[id]/+page.svelte`) — apply the palette to cells, grid, header, action buttons
+- Use the existing @theme overrides and CSS vars already in app.css — don't add new inline hex values
+
+## Steps
+
+1. Fix `src/app.css`: body background-color → var(--background), add .dark body override, remove redundant hardcoded value
+2. Fix `src/lib/components/ui/button/button.svelte`: remove rounded-md from sm and lg size variants
+3. Extend aesthetic to dashboard cards and bingo board pages
+4. Run `npm run lint` — fix any errors
+5. Run `npx prettier --write src/` — format
+6. Commit: "fix: address PR review — dark mode body bg, pill button variants, extend aesthetic to boards"
+7. Push:
+   git config --global credential.helper ""
+   git remote set-url origin https://x-access-token:$GH_TOKEN@github.com/xsaardo/bingo.git
+   GIT_ASKPASS=true git push origin fix/issue-169

--- a/src/app.css
+++ b/src/app.css
@@ -3,37 +3,87 @@
 
 @theme {
   --font-sans: 'Geist Mono', monospace;
+
+  /* =====================================================
+     Journaling palette — royal blue-indigo + lavender-gray
+     Override Tailwind's built-in blue scale so that all
+     hardcoded `bg-blue-600`, `text-blue-700` etc. cascade
+     to the new royal blue-indigo hue (#2D25CC).
+     ===================================================== */
+  --color-blue-50: oklch(0.96 0.018 268);
+  --color-blue-100: oklch(0.92 0.03 268);
+  --color-blue-200: oklch(0.86 0.055 268);
+  --color-blue-300: oklch(0.77 0.1 268);
+  --color-blue-400: oklch(0.66 0.16 268);
+  --color-blue-500: oklch(0.54 0.23 268);
+  --color-blue-600: oklch(0.43 0.27 268); /* ≈ #2D25CC royal blue-indigo */
+  --color-blue-700: oklch(0.37 0.255 268);
+  --color-blue-800: oklch(0.3 0.22 268);
+  --color-blue-900: oklch(0.23 0.18 268);
+  --color-blue-950: oklch(0.17 0.14 268);
+
+  /* Warm lavender-gray neutrals — replaces pure grays
+     so `text-gray-900`, `bg-gray-200` etc. carry the palette hue */
+  --color-gray-50: oklch(0.975 0.006 267);
+  --color-gray-100: oklch(0.955 0.008 267);
+  --color-gray-200: oklch(0.922 0.01 267); /* ≈ border-gray-200 soft lavender */
+  --color-gray-300: oklch(0.88 0.012 267);
+  --color-gray-400: oklch(0.78 0.012 267);
+  --color-gray-500: oklch(0.66 0.012 267);
+  --color-gray-600: oklch(0.53 0.012 267);
+  --color-gray-700: oklch(0.42 0.01 267);
+  --color-gray-800: oklch(0.31 0.008 267);
+  --color-gray-900: oklch(0.22 0.006 267);
+  --color-gray-950: oklch(0.15 0.004 267);
+
+  /* =====================================================
+     Flat 2D rendering — eliminate all box shadows
+     so shadow-sm, shadow, shadow-md, shadow-lg, shadow-xl
+     all collapse to a very subtle border instead of depth.
+     ===================================================== */
+  --shadow-xs: 0 0 0 1px oklch(0.9 0.012 267 / 0.6);
+  --shadow-sm: 0 0 0 1px oklch(0.9 0.012 267 / 0.6);
+  --shadow: 0 0 0 1px oklch(0.88 0.015 267 / 0.7);
+  --shadow-md: 0 0 0 1px oklch(0.86 0.015 267 / 0.8);
+  --shadow-lg: 0 0 0 1px oklch(0.84 0.018 267 / 0.8);
+  --shadow-xl: 0 0 0 1px oklch(0.82 0.02 267 / 0.9);
+  --shadow-2xl: 0 0 0 1px oklch(0.8 0.022 267);
 }
 
 /*
   shadcn-svelte CSS variables (oklch format)
-  Primary color mapped to blue-600
+  Primary mapped to royal blue-indigo (#2D25CC)
+  Background mapped to pale lavender-gray (#E8E9F0)
 */
 body {
   font-family: 'Geist Mono', monospace;
+  /* Pale lavender-gray base with dot-grid bullet-journal texture */
+  background-color: oklch(0.932 0.01 267); /* ≈ #E8E9F0 */
+  background-image: radial-gradient(circle, oklch(0.82 0.018 267) 1.2px, transparent 1.2px);
+  background-size: 22px 22px;
 }
 
 :root {
-  --radius: 0.5rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.511 0.262 264.052); /* blue-600 */
+  --radius: 0.75rem;
+  --background: oklch(0.932 0.01 267); /* pale lavender-gray ≈ #E8E9F0 */
+  --foreground: oklch(0.22 0.006 267);
+  --card: oklch(1 0 0); /* flat white cards */
+  --card-foreground: oklch(0.22 0.006 267);
+  --popover: oklch(1 0 0); /* flat white popovers */
+  --popover-foreground: oklch(0.22 0.006 267);
+  --primary: oklch(0.43 0.27 268); /* deep royal blue-indigo ≈ #2D25CC */
   --primary-foreground: oklch(1 0 0);
-  --secondary: oklch(0.967 0.003 264.542);
-  --secondary-foreground: oklch(0.21 0.034 264.665);
-  --muted: oklch(0.967 0.003 264.542);
-  --muted-foreground: oklch(0.551 0.027 264.364);
-  --accent: oklch(0.967 0.003 264.542);
-  --accent-foreground: oklch(0.21 0.034 264.665);
+  --secondary: oklch(0.955 0.008 267);
+  --secondary-foreground: oklch(0.31 0.008 267);
+  --muted: oklch(0.955 0.008 267);
+  --muted-foreground: oklch(0.53 0.012 267);
+  --accent: oklch(0.955 0.008 267);
+  --accent-foreground: oklch(0.31 0.008 267);
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(1 0 0);
-  --border: oklch(0.928 0.006 264.531);
-  --input: oklch(0.928 0.006 264.531);
-  --ring: oklch(0.511 0.262 264.052); /* blue-600 */
+  --border: oklch(0.922 0.01 267); /* soft lavender-gray border */
+  --input: oklch(0.922 0.01 267);
+  --ring: oklch(0.43 0.27 268); /* matches primary */
 }
 
 .dark {
@@ -43,7 +93,7 @@ body {
   --card-foreground: oklch(0.985 0 0);
   --popover: oklch(0.205 0 0);
   --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.546 0.245 262.881); /* blue-500 for dark mode */
+  --primary: oklch(0.54 0.23 268); /* slightly lighter for dark mode */
   --primary-foreground: oklch(1 0 0);
   --secondary: oklch(0.269 0 0);
   --secondary-foreground: oklch(0.985 0 0);
@@ -55,7 +105,7 @@ body {
   --destructive-foreground: oklch(1 0 0);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.546 0.245 262.881);
+  --ring: oklch(0.54 0.23 268);
 }
 
 .theme-horse {

--- a/src/app.css
+++ b/src/app.css
@@ -58,9 +58,14 @@
 body {
   font-family: 'Geist Mono', monospace;
   /* Pale lavender-gray base with dot-grid bullet-journal texture */
-  background-color: oklch(0.932 0.01 267); /* ≈ #E8E9F0 */
+  background-color: var(--background);
   background-image: radial-gradient(circle, oklch(0.82 0.018 267) 1.2px, transparent 1.2px);
   background-size: 22px 22px;
+}
+
+.dark body {
+  background-color: var(--background);
+  background-image: none; /* remove dot-grid in dark mode — dots are light-hued and will glare */
 }
 
 :root {

--- a/src/lib/components/BoardCard.svelte
+++ b/src/lib/components/BoardCard.svelte
@@ -111,10 +111,10 @@
 <a
   href="/boards/{board.id}"
   data-testid="board-card"
-  class="block bg-white rounded-lg shadow-sm border border-gray-200 hover:shadow-md hover:border-blue-300 transition-all duration-200 overflow-hidden group"
+  class="block bg-card rounded-2xl shadow-sm border border-border hover:shadow-md hover:border-primary/40 transition-all duration-200 overflow-hidden group"
 >
   <!-- Header -->
-  <div class="p-4 border-b border-gray-100">
+  <div class="p-4 border-b border-border">
     <div class="flex items-start justify-between">
       <div class="flex-1 min-w-0">
         {#if isEditing}
@@ -127,12 +127,12 @@
                 onblur={saveName}
                 disabled={saving}
                 maxlength={100}
-                class="flex-1 text-lg font-semibold text-gray-900 border border-blue-400 rounded px-2 py-0.5 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                class="flex-1 text-lg font-semibold text-foreground border border-primary rounded-full px-3 py-0.5 focus:outline-none focus:ring-2 focus:ring-ring disabled:opacity-50"
                 use:focusOnMount
               />
               <button
                 onclick={cancelEdit}
-                class="flex-shrink-0 p-1 text-gray-400 hover:text-gray-600 rounded-lg transition-colors"
+                class="flex-shrink-0 p-1 text-muted-foreground hover:text-foreground rounded-full transition-colors"
                 title="Cancel"
                 type="button"
               >
@@ -147,22 +147,22 @@
               </button>
             </div>
             {#if saveError}
-              <p class="text-xs text-red-500">{saveError}</p>
+              <p class="text-xs text-destructive">{saveError}</p>
             {/if}
             {#if saving}
-              <p class="text-xs text-gray-400">Saving...</p>
+              <p class="text-xs text-muted-foreground">Saving...</p>
             {/if}
           </div>
         {:else}
           <div class="flex items-center gap-1 group/name">
             <h3
-              class="text-lg font-semibold text-gray-900 truncate group-hover:text-blue-600 transition-colors"
+              class="text-lg font-semibold text-foreground truncate group-hover:text-primary transition-colors"
             >
               {board.name}
             </h3>
             <button
               onclick={handleEditClick}
-              class="flex-shrink-0 p-1 text-gray-300 hover:text-blue-500 rounded-lg opacity-100 sm:opacity-0 sm:group-hover/name:opacity-100 transition-all"
+              class="flex-shrink-0 p-1 text-muted-foreground hover:text-primary rounded-full opacity-100 sm:opacity-0 sm:group-hover/name:opacity-100 transition-all"
               title="Rename board"
               type="button"
             >
@@ -183,7 +183,7 @@
       {#if onDelete}
         <button
           onclick={handleDeleteClick}
-          class="flex-shrink-0 ml-2 p-2 text-gray-400 hover:text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+          class="flex-shrink-0 ml-2 p-2 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded-full transition-colors"
           title="Delete board"
           aria-label="Delete board"
           data-testid="delete-board-button"
@@ -206,16 +206,16 @@
     <!-- Progress Bar -->
     <div class="mb-3">
       <div class="flex items-center justify-between mb-2">
-        <span class="text-sm font-medium text-gray-700">Progress</span>
-        <span class="text-sm font-semibold text-blue-600">{completionPercentage}%</span>
+        <span class="text-sm font-medium text-foreground">Progress</span>
+        <span class="text-sm font-semibold text-primary">{completionPercentage}%</span>
       </div>
-      <div class="w-full bg-gray-200 rounded-full h-2 overflow-hidden">
+      <div class="w-full bg-muted rounded-full h-2 overflow-hidden">
         <div
-          class="bg-blue-600 h-2 rounded-full transition-all duration-300"
+          class="bg-primary h-2 rounded-full transition-all duration-300"
           style="width: {completionPercentage}%"
         ></div>
       </div>
-      <p class="text-xs text-gray-500 mt-1">
+      <p class="text-xs text-muted-foreground mt-1">
         {completedGoals} of {totalGoals} goals completed
       </p>
     </div>
@@ -248,7 +248,7 @@
             Complete
           </Badge>
         {:else if completedGoals > 0}
-          <Badge variant="outline" class="border-blue-400 bg-blue-50 text-blue-700">
+          <Badge variant="outline" class="border-primary/60 bg-blue-50 text-primary">
             <svg fill="none" stroke="currentColor" viewBox="0 0 24 24">
               <path
                 stroke-linecap="round"
@@ -274,7 +274,7 @@
         {/if}
       </div>
 
-      <span class="text-xs text-gray-400">Created {formatDate(board.createdAt)}</span>
+      <span class="text-xs text-muted-foreground">Created {formatDate(board.createdAt)}</span>
     </div>
   </div>
 </a>

--- a/src/lib/components/ui/button/button.svelte
+++ b/src/lib/components/ui/button/button.svelte
@@ -2,7 +2,7 @@
   import { tv, type VariantProps } from 'tailwind-variants';
 
   export const buttonVariants = tv({
-    base: 'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
+    base: 'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-full text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-[var(--ring)] disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:size-4 [&_svg]:shrink-0',
     variants: {
       variant: {
         default:

--- a/src/lib/components/ui/button/button.svelte
+++ b/src/lib/components/ui/button/button.svelte
@@ -18,8 +18,8 @@
       },
       size: {
         default: 'h-9 px-4 py-2',
-        sm: 'h-8 rounded-md px-3 text-xs',
-        lg: 'h-10 rounded-md px-8',
+        sm: 'h-8 px-3 text-xs',
+        lg: 'h-10 px-8',
         icon: 'size-9',
         'icon-sm': 'size-8',
         'icon-lg': 'size-10'

--- a/src/routes/boards/[id]/+page.svelte
+++ b/src/routes/boards/[id]/+page.svelte
@@ -96,18 +96,18 @@
 <AuthGuard>
   <div class="h-screen flex flex-col">
     <!-- Header -->
-    <header class="bg-white border-b border-gray-200">
+    <header class="bg-card border-b border-border">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
         <div class="flex items-center justify-between">
           <a href="/" class="flex items-center space-x-3">
             <Logo />
-            <span class="text-xl font-bold text-gray-900">BINGOALS</span>
+            <span class="text-xl font-bold text-foreground">BINGOALS</span>
           </a>
 
           <div class="flex items-center gap-3">
             {#if !$isAnonymous}
               <Button variant="ghost" href="/dashboard">My Boards</Button>
-              <div class="h-5 w-px bg-gray-200"></div>
+              <div class="h-5 w-px bg-border"></div>
             {/if}
 
             {#if $currentBoard}
@@ -261,18 +261,18 @@
       {#if $currentBoardLoading}
         <!-- Loading State -->
         <div
-          class="bg-white rounded-lg shadow-sm border border-gray-200 p-12 text-center"
+          class="bg-card rounded-2xl shadow-sm border border-border p-12 text-center"
           aria-busy="true"
         >
           <div
-            class="animate-spin rounded-full h-12 w-12 border-b-4 border-blue-600 mx-auto mb-4"
+            class="animate-spin rounded-full h-12 w-12 border-b-4 border-primary mx-auto mb-4"
             aria-label="Loading board"
           ></div>
-          <p class="text-gray-600">Loading board...</p>
+          <p class="text-muted-foreground">Loading board...</p>
         </div>
       {:else if $currentBoardError}
         <!-- Error State -->
-        <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-8">
+        <div class="bg-card rounded-2xl shadow-sm border border-border p-8">
           <div class="max-w-md mx-auto space-y-4">
             <ErrorAlert error={$currentBoardError} />
             <div class="flex justify-center space-x-3">

--- a/src/routes/dashboard/+page.svelte
+++ b/src/routes/dashboard/+page.svelte
@@ -71,18 +71,18 @@
 <AuthGuard>
   <div class="min-h-screen">
     <!-- Header -->
-    <header class="bg-white border-b border-gray-200">
+    <header class="bg-card border-b border-border">
       <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-4">
         <div class="flex items-center justify-between">
           <a href="/" class="flex items-center space-x-3">
             <Logo />
-            <h1 class="text-xl font-bold text-gray-900">BINGOALS</h1>
+            <h1 class="text-xl font-bold text-foreground">BINGOALS</h1>
           </a>
 
           <div class="flex items-center gap-3">
             <button
               onclick={handleCreateBoard}
-              class="flex items-center px-4 py-2 text-sm bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors shadow-sm hover:shadow-md"
+              class="flex items-center px-4 py-2 text-sm bg-primary hover:bg-primary/90 text-primary-foreground font-medium rounded-full transition-colors shadow"
             >
               <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path
@@ -103,9 +103,9 @@
     <!-- Main Content -->
     <main class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
       <!-- Page Header -->
-      <div class="mb-8 inline-block bg-white/70 backdrop-blur-sm rounded-2xl px-5 py-3">
-        <h2 class="text-3xl font-bold text-gray-900">My Boards</h2>
-        <p class="text-gray-600 mt-1">Create and manage your bingo boards</p>
+      <div class="mb-8 inline-block bg-card/70 backdrop-blur-sm rounded-2xl px-5 py-3 shadow-sm">
+        <h2 class="text-3xl font-bold text-foreground">My Boards</h2>
+        <p class="text-muted-foreground mt-1">Create and manage your bingo boards</p>
       </div>
 
       <!-- Error State -->
@@ -115,7 +115,7 @@
           <div class="flex justify-center">
             <button
               onclick={handleRetryFetch}
-              class="px-6 py-2.5 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors shadow-sm hover:shadow-md"
+              class="px-6 py-2.5 bg-primary hover:bg-primary/90 text-primary-foreground font-medium rounded-full transition-colors shadow"
             >
               Retry
             </button>
@@ -125,23 +125,23 @@
         <!-- Loading State -->
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6" aria-busy="true">
           {#each Array(3) as _}
-            <div class="bg-white rounded-lg shadow-sm border border-gray-200 p-6 animate-pulse">
-              <div class="h-6 bg-gray-200 rounded w-3/4 mb-4"></div>
-              <div class="h-4 bg-gray-200 rounded w-1/2 mb-4"></div>
-              <div class="h-2 bg-gray-200 rounded w-full mb-2"></div>
-              <div class="h-4 bg-gray-200 rounded w-1/4"></div>
+            <div class="bg-card rounded-2xl shadow-sm border border-border p-6 animate-pulse">
+              <div class="h-6 bg-muted rounded-full w-3/4 mb-4"></div>
+              <div class="h-4 bg-muted rounded-full w-1/2 mb-4"></div>
+              <div class="h-2 bg-muted rounded-full w-full mb-2"></div>
+              <div class="h-4 bg-muted rounded-full w-1/4"></div>
             </div>
           {/each}
         </div>
       {:else if !$hasBoards}
         <!-- Empty State -->
-        <div class="bg-white rounded-2xl shadow-sm border border-gray-200 p-12 text-center">
+        <div class="bg-card rounded-2xl shadow-sm border border-border p-12 text-center">
           <div class="max-w-md mx-auto">
             <div
-              class="inline-flex items-center justify-center w-20 h-20 bg-blue-100 rounded-full mb-6"
+              class="inline-flex items-center justify-center w-20 h-20 bg-blue-50 rounded-full mb-6"
             >
               <svg
-                class="w-10 h-10 text-blue-600"
+                class="w-10 h-10 text-primary"
                 fill="none"
                 stroke="currentColor"
                 viewBox="0 0 24 24"
@@ -154,13 +154,13 @@
                 />
               </svg>
             </div>
-            <h3 class="text-2xl font-bold text-gray-900 mb-2">No boards yet</h3>
-            <p class="text-gray-600 mb-6">
+            <h3 class="text-2xl font-bold text-foreground mb-2">No boards yet</h3>
+            <p class="text-muted-foreground mb-6">
               Create your first bingo board to start tracking your goals and achievements!
             </p>
             <button
               onclick={handleCreateBoard}
-              class="inline-flex items-center px-6 py-3 bg-blue-600 hover:bg-blue-700 text-white font-semibold rounded-lg transition-colors shadow-lg hover:shadow-xl"
+              class="inline-flex items-center px-6 py-3 bg-primary hover:bg-primary/90 text-primary-foreground font-semibold rounded-full transition-colors shadow"
             >
               <svg class="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
                 <path


### PR DESCRIPTION
## Summary

Redesign the Bingo app UI using a whimsical minimalist journaling aesthetic — pale lavender-gray background with a dot-grid bullet journal texture, deep royal blue-indigo as the single accent color, pill-shaped buttons, flat 2D cards, and monospaced type throughout.

## Changes

### src/app.css (token-level, cascades everywhere)
- @theme blue scale override: All Tailwind bg-blue-*, text-blue-*, border-blue-* classes now resolve to royal blue-indigo (~#2D25CC)
- @theme gray scale override: All text-gray-*, bg-gray-*, border-gray-* classes now use warm lavender-tinted neutrals (#E8E9F0 family)
- :root CSS vars: --background to pale lavender-gray, --primary + --ring to deep royal blue-indigo, --card/--popover stay flat white
- Dot-grid texture on body via CSS radial-gradient (bullet-journal paper)
- Flat shadow tokens: shadow-sm through shadow-2xl replaced with 1px border-like rings
- --radius bumped from 0.5rem to 0.75rem for softer cards

### src/lib/components/ui/button/button.svelte
- Button base class: rounded-md to rounded-full (pill shape)

## Testing
- npx svelte-check: same error count as main (2 pre-existing Supabase env errors)
- npx prettier applied to changed files
- No new TypeScript or Svelte errors introduced

Fixes xsaardo/bingo#169